### PR TITLE
fix a rowCounts bug

### DIFF
--- a/src/rowCounts_TYPE-template.h
+++ b/src/rowCounts_TYPE-template.h
@@ -138,11 +138,11 @@ void METHOD_NAME(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t ncol, X_C_TYPE value, int 
       kk = 0;
       for (jj=0; jj < ncol; jj++) {
         for (ii=0; ii < nrow; ii++) {
+          xvalue = x[kk++];
           count = ans[ii];
           /* Nothing more to do on this row? */
           if (count == NA_INTEGER) continue;
   
-          xvalue = x[kk++];
           if (xvalue == value) {
             ans[ii] = count + 1;
           } else {

--- a/tests/rowCounts.R
+++ b/tests/rowCounts.R
@@ -127,3 +127,10 @@ for (na.rm in c(FALSE, TRUE)) {
     stopifnot(identical(c,r1[2]))
   }
 }
+
+# NA row
+x <- matrix(0, nrow=2, ncol=2)
+x[1,] <- NA_integer_
+r0 <- rowCounts(x, value=0)
+r1 <- rowCounts_R(x, value=0)
+stopifnot(identical(r0,r1))


### PR DESCRIPTION
The function rowCounts() seems to have a bug. 
Here is a case:

> x <- matrix(0, nrow=2, ncol=2)
> x[1,] <- NA_integer_
> r0 <- rowCounts(x, value=0)
> r1 <- rowCounts_R(x, value=0)
> print(r0)
[1] NA  NA
> print(r1)
[1] NA  2
