### PR TITLE
Bug fix: x_OP_y should ignore na.rm well for subtractions and divisions

### DIFF
--- a/src/x_OP_y_TYPE-template.h
+++ b/src/x_OP_y_TYPE-template.h
@@ -35,10 +35,7 @@
 #endif
     return (double)x - (double)y;
   }
-  #define FUN_narm CONCAT_MACROS(FUN, METHOD_NAME_T)
-  static R_INLINE double FUN_narm(X_C_TYPE x, Y_C_TYPE y) {
-    return (double)x - (double)y;
-  }
+  #define FUN_narm FUN_no_NA
 #elif OP == '*'
   #define METHOD_NAME_T CONCAT_MACROS(METHOD_NAME, Mul)
   #define FUN_no_NA CONCAT_MACROS(FUN_no_NA, METHOD_NAME_T)
@@ -73,10 +70,7 @@
 #endif
     return (double)x / (double)y;
   }
-  #define FUN_narm CONCAT_MACROS(FUN, METHOD_NAME_T)
-  static R_INLINE double FUN_narm(X_C_TYPE x, Y_C_TYPE y) {
-    return (double)x / (double)y;
-  }
+  #define FUN_narm FUN_no_NA
 #else
   #error "INTERNAL ERROR: Failed to set C inline function FUN(x, y): Unknown OP"
 #endif
@@ -254,6 +248,7 @@ void METHOD_NAME_T(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t ncol,
 }
 
 #undef FUN
+#undef FUN_narm
 #undef METHOD_NAME_T
 
 /* Undo template macros */

--- a/tests/x_OP_y.R
+++ b/tests/x_OP_y.R
@@ -143,8 +143,10 @@ for (x in xs) {
       for (OP in c("+", "-", "*", "/")) {
         for (na.rm in c(FALSE, TRUE)) {
           cat(sprintf("mode='%s', OP='%s', na.rm=%s\n", mode, OP, na.rm))
-          z0 <- x_OP_y_R(x, y, OP)
-          z <- x_OP_y(x, y, OP)
+          suppressWarnings({
+            z0 <- x_OP_y_R(x, y, OP, na.rm=na.rm)
+            z <- x_OP_y(x, y, OP, na.rm=na.rm)
+          })
           str(z)
           stopifnot(all.equal(z, z0))
         }


### PR DESCRIPTION
The problem in #34 seems to still exist when `na.rm = TRUE`.
Fix test case in commit 4828454.