### PR TITLE
# should not convert NAN to int [#48]

### DIFF
--- a/src/x_OP_y_TYPE-template.h
+++ b/src/x_OP_y_TYPE-template.h
@@ -103,8 +103,10 @@ void METHOD_NAME_T(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t ncol,
             ok = 0;
             value = NA_REAL;
           }
-#endif
+          ans[kk] = ISNAN(value) ? NA_INTEGER : (ANS_C_TYPE) value;
+#else
           ans[kk] = (ANS_C_TYPE) value;
+#endif
           if (++xi >= nx) xi = 0;
           if (++row >= nrow) {         /* Current index in t(x):  */
             row = 0;                   /* col = xi / nrow;        */
@@ -123,8 +125,10 @@ void METHOD_NAME_T(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t ncol,
             ok = 0;
             value = NA_REAL;
           }
-#endif
+          ans[kk] = ISNAN(value) ? NA_INTEGER : (ANS_C_TYPE) value;
+#else
           ans[kk] = (ANS_C_TYPE) value;
+#endif
           if (++xi >= nx) xi = 0;
           if (++row >= nrow) {         /* Current index in t(x):  */
             row = 0;                   /* col = xi / nrow;        */
@@ -145,8 +149,10 @@ void METHOD_NAME_T(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t ncol,
             ok = 0;
             value = NA_REAL;
           }
-#endif
+          ans[kk] = ISNAN(value) ? NA_INTEGER : (ANS_C_TYPE) value;
+#else
           ans[kk] = (ANS_C_TYPE) value;
+#endif
           if (++xi >= nx) xi = 0;
           if (++row >= nrow) {         /* Current index in t(x):  */
             row = 0;                   /* col = xi / nrow;        */
@@ -165,8 +171,10 @@ void METHOD_NAME_T(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t ncol,
             ok = 0;
             value = NA_REAL;
           }
-#endif
+          ans[kk] = ISNAN(value) ? NA_INTEGER : (ANS_C_TYPE) value;
+#else
           ans[kk] = (ANS_C_TYPE) value;
+#endif
           if (++xi >= nx) xi = 0;
           if (++row >= nrow) {         /* Current index in t(x):  */
             row = 0;                   /* col = xi / nrow;        */
@@ -189,8 +197,10 @@ void METHOD_NAME_T(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t ncol,
             ok = 0;
             value = NA_REAL;
           }
-#endif
+          ans[kk] = ISNAN(value) ? NA_INTEGER : (ANS_C_TYPE) value;
+#else
           ans[kk] = (ANS_C_TYPE) value;
+#endif
           if (++xi >= nx) xi = 0;
           if (++yi >= ny) yi = 0;
         }
@@ -202,8 +212,10 @@ void METHOD_NAME_T(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t ncol,
             ok = 0;
             value = NA_REAL;
           }
-#endif
+          ans[kk] = ISNAN(value) ? NA_INTEGER : (ANS_C_TYPE) value;
+#else
           ans[kk] = (ANS_C_TYPE) value;
+#endif
           if (++xi >= nx) xi = 0;
           if (++yi >= ny) yi = 0;
         }
@@ -217,8 +229,10 @@ void METHOD_NAME_T(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t ncol,
             ok = 0;
             value = NA_REAL;
           }
-#endif
+          ans[kk] = ISNAN(value) ? NA_INTEGER : (ANS_C_TYPE) value;
+#else
           ans[kk] = (ANS_C_TYPE) value;
+#endif
           if (++xi >= nx) xi = 0;
           if (++yi >= ny) yi = 0;
         }
@@ -230,8 +244,10 @@ void METHOD_NAME_T(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t ncol,
             ok = 0;
             value = NA_REAL;
           }
-#endif
+          ans[kk] = ISNAN(value) ? NA_INTEGER : (ANS_C_TYPE) value;
+#else
           ans[kk] = (ANS_C_TYPE) value;
+#endif
           if (++xi >= nx) xi = 0;
           if (++yi >= ny) yi = 0;
         }


### PR DESCRIPTION
This PR trys to fix issue #48.

Here's my suggestions:

1. I don't think the problem is related to `R_INT_MIN`, because `R_INT_MIN` is really defined as -`INT_MAX` in R [[1]](https://github.com/wch/r-source/blob/trunk/src/main/arithmetic.c#L305), while `INT_MIN` (i.e. `(-INT_MAX - 1)`) is taken as `NA_INTEGER` [[2]](https://github.com/wch/r-source/blob/trunk/src/main/arithmetic.c#L163).
1. I think this issue is probably due to the coercion of `(int) R_NaReal`, which **should be avoided**, because **"IEEE-754 does not specify what happens when you convert a floating-point NaN to an integer"**. [[3]](http://stackoverflow.com/a/10400095/1764296)
