### PR TITLE
Ensure result of col-/rowAvgsPerColSet() is a matrix and not a vector

### DIFF
--- a/R/rowAvgsPerColSet.R
+++ b/R/rowAvgsPerColSet.R
@@ -128,8 +128,12 @@ rowAvgsPerColSet <- function(X, W = NULL, rows = NULL, S,
     Zjj
   })
 
-  # Ensure that Z is a matrix and not a vector
-  Z <- as.matrix(Z)
+  # apply() drops 2nd dimension if nrow(X) <= 1 (and FUN returns a vector of
+  # length nrow(X) as it should), cf. ?apply
+  if (!is.matrix(Z)) {
+    stopifnot(dimX[1] <= 1L)
+    dim(Z) <- c(length(Z), nbrOfSets)
+  }
 
   # Sanity check
   stopifnot(dim(Z) == c(dimX[1L], nbrOfSets))

--- a/R/rowAvgsPerColSet.R
+++ b/R/rowAvgsPerColSet.R
@@ -128,6 +128,9 @@ rowAvgsPerColSet <- function(X, W = NULL, rows = NULL, S,
     Zjj
   })
 
+  # Ensure that Z is a matrix and not a vector
+  Z <- as.matrix(Z)
+
   # Sanity check
   stopifnot(dim(Z) == c(dimX[1L], nbrOfSets))
 

--- a/tests/rowAvgsPerColSet.R
+++ b/tests/rowAvgsPerColSet.R
@@ -84,10 +84,12 @@ z2 <- colAvgsPerRowSet(x, W = w, S = s, FUN = colWeightedMeans)
 print(z2)
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - -
-# Result should always be a matrix
+# Result should always be a matrix, including when nrow(X) <= 1
 # (https://github.com/HenrikBengtsson/matrixStats/issues/108)
 # - - - - - - - - - - - - - - - - - - - - - - - - - -
-X <- matrix(1)
-S <- matrix(1)
-z <- rowAvgsPerColSet(X, S = S)
-stopifnot(is.matrix(z))
+X <- matrix(1:3, nrow = 1L, ncol = 3L)
+S <- matrix(1, nrow = 1L, ncol = 1L)
+z1 <- rowAvgsPerColSet(X, S = S)
+stopifnot(is.matrix(z1))
+z2 <- rowAvgsPerColSet(X, S = S, rows = 0)
+stopifnot(is.matrix(z2))

--- a/tests/rowAvgsPerColSet.R
+++ b/tests/rowAvgsPerColSet.R
@@ -82,3 +82,12 @@ z1 <- rowAvgsPerColSet(x, W = w, S = s, FUN = rowWeightedMeans)
 print(z1)
 z2 <- colAvgsPerRowSet(x, W = w, S = s, FUN = colWeightedMeans)
 print(z2)
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Result should always be a matrix
+# (https://github.com/HenrikBengtsson/matrixStats/issues/108)
+# - - - - - - - - - - - - - - - - - - - - - - - - - -
+X <- matrix(1)
+S <- matrix(1)
+z <- rowAvgsPerColSet(X, S = S)
+stopifnot(is.matrix(z))


### PR DESCRIPTION
Bug fix for #108

I couldn't update the `NEWS` without screwing up the line endings but here's something you might add

```
 o col-/rowAvgsPerColSet() would return vector rather than matrix if
   dim(X) == c(1L, 1L). Thanks to Peter Hickey (Johns Hopkins University) for
   troubleshooting and providing a fix.
```