### PR TITLE
remove unused variable

### DIFF
--- a/src/anyMissing.c
+++ b/src/anyMissing.c
@@ -13,7 +13,6 @@
 
 
 SEXP anyMissing(SEXP x, SEXP idxs) {
-  SEXP ans;
   R_xlen_t nx;
 
   nx = xlength(x);


### PR DESCRIPTION
This removes one nag from the beloved compiler. From an installation of 0.54.0 just now:

```sh
[...]
ccache gcc -I"/usr/share/R/include" -DNDEBUG      -fpic  -g -O3 -Wall -pipe -pedantic -DBOOST_NO_AUTO_PTR  -std=gnu99 -march=native -c anyMissing.c -o anyMissing.o
anyMissing.c: In function ‘anyMissing’:
anyMissing.c:16:8: warning: unused variable ‘ans’ [-Wunused-variable]
   SEXP ans;
        ^~~
ccache gcc -I"/usr/share/R/include" -DNDEBUG      -fpic  -g -O3 -Wall -pipe -pedantic -DBOOST_NO_AUTO_PTR  -std=gnu99 -march=native -c binCounts.c -o binCounts.o
[...]
```