### PR TITLE
Add ties.method's first, last, random, and dense to row|colRanks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,8 +8,7 @@ Suggests:
   knitr,
   microbenchmark,
   R.devices,
-  R.rsp,
-  data.table (>= 1.9.6)
+  R.rsp
 VignetteBuilder: R.rsp
 Date: 2018-07-23
 Title: Functions that Apply to Rows and Columns of Matrices (and to Vectors)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,8 @@ Suggests:
   knitr,
   microbenchmark,
   R.devices,
-  R.rsp
+  R.rsp,
+  data.table (>= 1.9.6)
 VignetteBuilder: R.rsp
 Date: 2018-07-23
 Title: Functions that Apply to Rows and Columns of Matrices (and to Vectors)
@@ -21,8 +22,9 @@ Authors@R: c(
   person("Harris", "Jaffee", role="ctb"),
   person("Dongcan", "Jiang", role="ctb"),
   person("Peter", "Langfelder", role="ctb"),
-  person("Peter", "Hickey", role="ctb"))
-Author: Henrik Bengtsson [aut, cre, cph], Hector Corrada Bravo [ctb], Robert Gentleman [ctb], Ola Hossjer [ctb], Harris Jaffee [ctb], Dongcan Jiang [ctb], Peter Langfelder [ctb], Peter Hickey [ctb]
+  person("Peter", "Hickey", role="ctb"),
+  person("Brian", "Montgomery", role="ctb"))
+Author: Henrik Bengtsson [aut, cre, cph], Hector Corrada Bravo [ctb], Robert Gentleman [ctb], Ola Hossjer [ctb], Harris Jaffee [ctb], Dongcan Jiang [ctb], Peter Langfelder [ctb], Peter Hickey [ctb], Brian Montgomery [ctb]
 Maintainer: Henrik Bengtsson <henrikb@braju.com>
 Description: High-performing functions operating on rows and columns of matrices, e.g. col / rowMedians(), col / rowRanks(), and col / rowSds().  Functions optimized per data type and for subsetted calculations such that both memory usage and processing time is minimized.  There are also optimized vector-based methods, e.g. binMeans(), madDiff() and weightedMedian().
 License: Artistic-2.0

--- a/R/rowRanks.R
+++ b/R/rowRanks.R
@@ -63,13 +63,14 @@
 #'
 #' @export
 rowRanks <- function(x, rows = NULL, cols = NULL,
-                     ties.method = c("max", "average", "min"),
+                     ties.method = c("average", "first", "last", "random",
+                                     "max", "min", "dense"),
                      dim. = dim(x), ...) {
   # Argument 'ties.method':
   ties.method <- ties.method[1L]
 
-  ties_method <- charmatch(ties.method, c("max", "average", "min"),
-                           nomatch = 0L)
+  ties_method <- charmatch(ties.method, c("average", "first", "last", "random",
+                                          "max", "min", "dense"), nomatch = 0L)
   if (ties_method == 0L) {
     stop("Unknown value of argument 'ties.method': ", ties.method)
   }
@@ -83,7 +84,8 @@ rowRanks <- function(x, rows = NULL, cols = NULL,
 #' @rdname rowRanks
 #' @export
 colRanks <- function(x, rows = NULL, cols = NULL,
-                     ties.method = c("max", "average", "min"),
+                     ties.method = c("average", "first", "last", "random",
+                                     "max", "min", "dense"),
                      dim. = dim(x), preserveShape = FALSE, ...) {
   # Argument 'ties.method':
   ties.method <- ties.method[1L]
@@ -91,8 +93,8 @@ colRanks <- function(x, rows = NULL, cols = NULL,
   # Argument 'preserveShape'
   preserveShape <- as.logical(preserveShape)
 
-  ties_method <- charmatch(ties.method, c("max", "average", "min"),
-                           nomatch = 0L)
+  ties_method <- charmatch(ties.method, c("average", "first", "last", "random",
+                                          "max", "min", "dense"), nomatch = 0L)
   if (ties_method == 0L) {
     stop("Unknown value of argument 'ties.method': ", ties.method)
   }

--- a/R/rowRanks.R
+++ b/R/rowRanks.R
@@ -66,7 +66,8 @@
 #'
 #' @export
 rowRanks <- function(x, rows = NULL, cols = NULL,
-                     ties.method = c("average", "first", "last", "random",
+                     # max is listed twice so that it remains the default for now
+                     ties.method = c("max", "average", "first", "last", "random",
                                      "max", "min", "dense"),
                      dim. = dim(x), ...) {
   # Argument 'ties.method':
@@ -87,7 +88,8 @@ rowRanks <- function(x, rows = NULL, cols = NULL,
 #' @rdname rowRanks
 #' @export
 colRanks <- function(x, rows = NULL, cols = NULL,
-                     ties.method = c("average", "first", "last", "random",
+                     # max is listed twice so that it remains the default for now
+                     ties.method = c("max", "average", "first", "last", "random",
                                      "max", "min", "dense"),
                      dim. = dim(x), preserveShape = FALSE, ...) {
   # Argument 'ties.method':

--- a/R/rowRanks.R
+++ b/R/rowRanks.R
@@ -52,12 +52,15 @@
 #' \code{na.last = "keep"} in the \code{\link[base]{rank}}() function.
 #'
 #' @author Hector Corrada Bravo and Harris Jaffee.  Peter Langfelder for adding
-#' 'ties.method' support.  Henrik Bengtsson adapted the original native
+#' 'ties.method' support.  Brian Montgomery for adding more 'ties.method's.
+#' Henrik Bengtsson adapted the original native
 #' implementation of \code{rowRanks()} from Robert Gentleman's \code{rowQ()} in
 #' the \pkg{Biobase} package.
 #'
-#' @seealso \code{\link[base]{rank}}().  For developers, see also Section
-#' 'Utility functions' in 'Writing R Extensions manual', particularly the
+#' @seealso \code{\link[base]{rank}}().  
+#' \code{\link[data.table]{frank}}() for ties.method 'dense'.  
+#' For developers, see also Section Utility functions' in 
+#' 'Writing R Extensions manual', particularly the
 #' native functions \code{R_qsort_I()} and \code{R_qsort_int_I()}.
 #' @keywords array iteration robust univar
 #'

--- a/man/rowRanks.Rd
+++ b/man/rowRanks.Rd
@@ -5,12 +5,13 @@
 \alias{colRanks}
 \title{Gets the rank of the elements in each row (column) of a matrix}
 \usage{
-rowRanks(x, rows = NULL, cols = NULL, ties.method = c("average",
-  "first", "last", "random", "max", "min", "dense"), dim. = dim(x), ...)
+rowRanks(x, rows = NULL, cols = NULL, ties.method = c("max",
+  "average", "first", "last", "random", "max", "min", "dense"),
+  dim. = dim(x), ...)
 
-colRanks(x, rows = NULL, cols = NULL, ties.method = c("average",
-  "first", "last", "random", "max", "min", "dense"), dim. = dim(x),
-  preserveShape = FALSE, ...)
+colRanks(x, rows = NULL, cols = NULL, ties.method = c("max",
+  "average", "first", "last", "random", "max", "min", "dense"),
+  dim. = dim(x), preserveShape = FALSE, ...)
 }
 \arguments{
 \item{x}{A \code{\link[base]{numeric}} or \code{\link[base]{integer}} NxK

--- a/man/rowRanks.Rd
+++ b/man/rowRanks.Rd
@@ -5,11 +5,12 @@
 \alias{colRanks}
 \title{Gets the rank of the elements in each row (column) of a matrix}
 \usage{
-rowRanks(x, rows = NULL, cols = NULL, ties.method = c("max",
-  "average", "min"), dim. = dim(x), ...)
+rowRanks(x, rows = NULL, cols = NULL, ties.method = c("average",
+  "first", "last", "random", "max", "min", "dense"), dim. = dim(x), ...)
 
-colRanks(x, rows = NULL, cols = NULL, ties.method = c("max",
-  "average", "min"), dim. = dim(x), preserveShape = FALSE, ...)
+colRanks(x, rows = NULL, cols = NULL, ties.method = c("average",
+  "first", "last", "random", "max", "min", "dense"), dim. = dim(x),
+  preserveShape = FALSE, ...)
 }
 \arguments{
 \item{x}{A \code{\link[base]{numeric}} or \code{\link[base]{integer}} NxK
@@ -69,13 +70,16 @@ result.
 }
 
 \seealso{
-\code{\link[base]{rank}}().  For developers, see also Section
-'Utility functions' in 'Writing R Extensions manual', particularly the
+\code{\link[base]{rank}}().  
+\code{\link[data.table]{frank}}() for ties.method 'dense'.  
+For developers, see also Section Utility functions' in 
+'Writing R Extensions manual', particularly the
 native functions \code{R_qsort_I()} and \code{R_qsort_int_I()}.
 }
 \author{
 Hector Corrada Bravo and Harris Jaffee.  Peter Langfelder for adding
-'ties.method' support.  Henrik Bengtsson adapted the original native
+'ties.method' support.  Brian Montgomery for adding more 'ties.method's.
+Henrik Bengtsson adapted the original native
 implementation of \code{rowRanks()} from Robert Gentleman's \code{rowQ()} in
 the \pkg{Biobase} package.
 }

--- a/src/rowRanksWithTies.c
+++ b/src/rowRanksWithTies.c
@@ -14,6 +14,23 @@
  * tiesMethod: 1: maximum, 2: average, 3:minimum
  * The returned rank is a REAL matrix to accomodate average ranks
  */
+/* Brian Montgomery's modifications:
+ * added tiesMethods first, last, random, and dense
+ * reordered to match base::ranks
+ * tiesMethod: 1: average, 2: first, 3: last, 5: random, 5: maximum, 6:minimum, 7:dense
+ */
+
+ // Arrange the elements from i to j of array in random order.
+ // Used in tiesMethod "random".
+ void SHUFFLE_INT(int *array, size_t i, size_t j) {
+     if (j > i) {
+         for (size_t k = i; k < j; k++) {
+           size_t l = k + (int) (unif_rand() * (j - k + 1));
+           SWAP(int, array[l], array[k]);
+         }
+     }
+ }
+
 SEXP rowRanksWithTies(SEXP x, SEXP dim, SEXP rows, SEXP cols, SEXP tiesMethod, SEXP byRow) {
   int tiesmethod, byrow;
   SEXP ans = NILSXP;
@@ -26,10 +43,9 @@ SEXP rowRanksWithTies(SEXP x, SEXP dim, SEXP rows, SEXP cols, SEXP tiesMethod, S
 
   /* Argument 'tiesMethod': */
   tiesmethod = asInteger(tiesMethod);
-  if (tiesmethod < 1 || tiesmethod > 3) {
-    error("Argument 'tiesMethod' is out of range [1,3]: %d", tiesmethod);
+  if (tiesmethod < 1 || tiesmethod > 7) {
+    error("Argument 'tiesMethod' is out of range [1,7]: %d", tiesmethod);
   }
-
   /* Argument 'rows' and 'cols': */
   R_xlen_t nrows, ncols;
   int rowsType, colsType;
@@ -44,36 +60,80 @@ SEXP rowRanksWithTies(SEXP x, SEXP dim, SEXP rows, SEXP cols, SEXP tiesMethod, S
     if (byrow) {
       switch (tiesmethod) {
         case 1:
-          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          rowRanksWithTies_Max_dbl[rowsType][colsType](REAL(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
-          UNPROTECT(1);
-          break;
-        case 2:
           PROTECT(ans = allocMatrix(REALSXP, nrows, ncols));
           rowRanksWithTies_Average_dbl[rowsType][colsType](REAL(x), nrow, ncol, crows, nrows, ccols, ncols, REAL(ans));
           UNPROTECT(1);
           break;
+        case 2:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          rowRanksWithTies_First_dbl[rowsType][colsType](REAL(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          UNPROTECT(1);
+          break;
         case 3:
           PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          rowRanksWithTies_Last_dbl[rowsType][colsType](REAL(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          UNPROTECT(1);
+          break;
+        case 4:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          GetRNGstate();
+          rowRanksWithTies_Random_dbl[rowsType][colsType](REAL(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          PutRNGstate();
+          UNPROTECT(1);
+          break;
+        case 5:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          rowRanksWithTies_Max_dbl[rowsType][colsType](REAL(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          UNPROTECT(1);
+          break;
+        case 6:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
           rowRanksWithTies_Min_dbl[rowsType][colsType](REAL(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          UNPROTECT(1);
+          break;
+        case 7:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          rowRanksWithTies_Dense_dbl[rowsType][colsType](REAL(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
           UNPROTECT(1);
           break;
       } /* switch */
     } else {
       switch (tiesmethod) {
         case 1:
-          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          colRanksWithTies_Max_dbl[rowsType][colsType](REAL(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
-          UNPROTECT(1);
-          break;
-        case 2:
           PROTECT(ans = allocMatrix(REALSXP, nrows, ncols));
           colRanksWithTies_Average_dbl[rowsType][colsType](REAL(x), nrow, ncol, crows, nrows, ccols, ncols, REAL(ans));
           UNPROTECT(1);
           break;
+        case 2:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          colRanksWithTies_First_dbl[rowsType][colsType](REAL(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          UNPROTECT(1);
+          break;
         case 3:
           PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          colRanksWithTies_Last_dbl[rowsType][colsType](REAL(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          UNPROTECT(1);
+          break;
+        case 4:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          GetRNGstate();
+          colRanksWithTies_Random_dbl[rowsType][colsType](REAL(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          PutRNGstate();
+          UNPROTECT(1);
+          break;
+        case 5:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          colRanksWithTies_Max_dbl[rowsType][colsType](REAL(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          UNPROTECT(1);
+          break;
+        case 6:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
           colRanksWithTies_Min_dbl[rowsType][colsType](REAL(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          UNPROTECT(1);
+          break;
+        case 7:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          colRanksWithTies_Dense_dbl[rowsType][colsType](REAL(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
           UNPROTECT(1);
           break;
       } /* switch */
@@ -82,36 +142,80 @@ SEXP rowRanksWithTies(SEXP x, SEXP dim, SEXP rows, SEXP cols, SEXP tiesMethod, S
     if (byrow) {
       switch (tiesmethod) {
         case 1:
-          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          rowRanksWithTies_Max_int[rowsType][colsType](INTEGER(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
-          UNPROTECT(1);
-          break;
-        case 2:
           PROTECT(ans = allocMatrix(REALSXP, nrows, ncols));
           rowRanksWithTies_Average_int[rowsType][colsType](INTEGER(x), nrow, ncol, crows, nrows, ccols, ncols, REAL(ans));
           UNPROTECT(1);
           break;
+        case 2:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          rowRanksWithTies_First_int[rowsType][colsType](INTEGER(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          UNPROTECT(1);
+          break;
         case 3:
           PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          rowRanksWithTies_Last_int[rowsType][colsType](INTEGER(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          UNPROTECT(1);
+          break;
+        case 4:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          GetRNGstate();
+          rowRanksWithTies_Random_int[rowsType][colsType](INTEGER(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          PutRNGstate();
+          UNPROTECT(1);
+          break;
+        case 5:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          rowRanksWithTies_Max_int[rowsType][colsType](INTEGER(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          UNPROTECT(1);
+          break;
+        case 6:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
           rowRanksWithTies_Min_int[rowsType][colsType](INTEGER(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          UNPROTECT(1);
+          break;
+        case 7:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          rowRanksWithTies_Dense_int[rowsType][colsType](INTEGER(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
           UNPROTECT(1);
           break;
       } /* switch */
     } else {
       switch (tiesmethod) {
         case 1:
-          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          colRanksWithTies_Max_int[rowsType][colsType](INTEGER(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
-          UNPROTECT(1);
-          break;
-        case 2:
           PROTECT(ans = allocMatrix(REALSXP, nrows, ncols));
           colRanksWithTies_Average_int[rowsType][colsType](INTEGER(x), nrow, ncol, crows, nrows, ccols, ncols, REAL(ans));
           UNPROTECT(1);
           break;
+        case 2:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          colRanksWithTies_First_int[rowsType][colsType](INTEGER(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          UNPROTECT(1);
+          break;
         case 3:
           PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          colRanksWithTies_Last_int[rowsType][colsType](INTEGER(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          UNPROTECT(1);
+          break;
+        case 4:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          GetRNGstate();
+          colRanksWithTies_Random_int[rowsType][colsType](INTEGER(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          PutRNGstate();
+          UNPROTECT(1);
+          break;
+        case 5:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          colRanksWithTies_Max_int[rowsType][colsType](INTEGER(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          UNPROTECT(1);
+          break;
+        case 6:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
           colRanksWithTies_Min_int[rowsType][colsType](INTEGER(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
+          UNPROTECT(1);
+          break;
+        case 7:
+          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
+          colRanksWithTies_Dense_int[rowsType][colsType](INTEGER(x), nrow, ncol, crows, nrows, ccols, ncols, INTEGER(ans));
           UNPROTECT(1);
           break;
       } /* switch */

--- a/src/rowRanksWithTies.c
+++ b/src/rowRanksWithTies.c
@@ -228,6 +228,8 @@ SEXP rowRanksWithTies(SEXP x, SEXP dim, SEXP rows, SEXP cols, SEXP tiesMethod, S
 
 /***************************************************************************
  HISTORY:
+ 2019-4-23 [BKM]
+  o Added more tiesMethods: first, last, random, and dense
  2015-06-12 [DJ]
   o Supported subsetted computation.
  2013-01-13 [HB]

--- a/src/rowRanksWithTies_lowlevel.h
+++ b/src/rowRanksWithTies_lowlevel.h
@@ -64,6 +64,109 @@ void rowRanksWithTies_Average_int_drows_dcols(int *x, R_xlen_t nrow, R_xlen_t nc
 #define RETURN_TYPE void
 #define ARGUMENTS_LIST X_C_TYPE *x, R_xlen_t nrow, R_xlen_t ncol, void *rows, R_xlen_t nrows, void *cols, R_xlen_t ncols, ANS_C_TYPE *ans
 
+/*****************************************************************
+ * ties.method = "average"
+ *****************************************************************/
+#define TIESMETHOD 'a' /* average */
+#define METHOD rowRanksWithTies_Average
+#define MARGIN 'r'
+#define X_TYPE 'r'
+#include "000.templates-gen-matrix.h"
+
+#define MARGIN 'r'
+#define X_TYPE 'i'
+#include "000.templates-gen-matrix.h"
+#undef METHOD
+
+#define METHOD colRanksWithTies_Average
+#define MARGIN 'c'
+#define X_TYPE 'r'
+#include "000.templates-gen-matrix.h"
+
+#define MARGIN 'c'
+#define X_TYPE 'i'
+#include "000.templates-gen-matrix.h"
+#undef METHOD
+#undef TIESMETHOD
+
+
+/*****************************************************************
+ * ties.method = "first"
+ *****************************************************************/
+#define TIESMETHOD 'f' /* first */
+#define METHOD rowRanksWithTies_First
+#define MARGIN 'r'
+#define X_TYPE 'r'
+#include "000.templates-gen-matrix.h"
+
+#define MARGIN 'r'
+#define X_TYPE 'i'
+#include "000.templates-gen-matrix.h"
+#undef METHOD
+
+#define METHOD colRanksWithTies_First
+#define MARGIN 'c'
+#define X_TYPE 'r'
+#include "000.templates-gen-matrix.h"
+
+#define MARGIN 'c'
+#define X_TYPE 'i'
+#include "000.templates-gen-matrix.h"
+#undef METHOD
+#undef TIESMETHOD
+
+
+/*****************************************************************
+ * ties.method = "last"
+ *****************************************************************/
+#define TIESMETHOD 'l' /* last */
+#define METHOD rowRanksWithTies_Last
+#define MARGIN 'r'
+#define X_TYPE 'r'
+#include "000.templates-gen-matrix.h"
+
+#define MARGIN 'r'
+#define X_TYPE 'i'
+#include "000.templates-gen-matrix.h"
+#undef METHOD
+
+#define METHOD colRanksWithTies_Last
+#define MARGIN 'c'
+#define X_TYPE 'r'
+#include "000.templates-gen-matrix.h"
+
+#define MARGIN 'c'
+#define X_TYPE 'i'
+#include "000.templates-gen-matrix.h"
+#undef METHOD
+#undef TIESMETHOD
+
+
+/*****************************************************************
+ * ties.method = "random"
+ *****************************************************************/
+#define TIESMETHOD 'r' /* random */
+#define METHOD rowRanksWithTies_Random
+#define MARGIN 'r'
+#define X_TYPE 'r'
+#include "000.templates-gen-matrix.h"
+
+#define MARGIN 'r'
+#define X_TYPE 'i'
+#include "000.templates-gen-matrix.h"
+#undef METHOD
+
+#define METHOD colRanksWithTies_Random
+#define MARGIN 'c'
+#define X_TYPE 'r'
+#include "000.templates-gen-matrix.h"
+
+#define MARGIN 'c'
+#define X_TYPE 'i'
+#include "000.templates-gen-matrix.h"
+#undef METHOD
+#undef TIESMETHOD
+
 
 /*****************************************************************
  * ties.method = "min"
@@ -118,10 +221,10 @@ void rowRanksWithTies_Average_int_drows_dcols(int *x, R_xlen_t nrow, R_xlen_t nc
 
 
 /*****************************************************************
- * ties.method = "average"
+ * ties.method = "dense"
  *****************************************************************/
-#define TIESMETHOD 'a' /* average */
-#define METHOD rowRanksWithTies_Average
+#define TIESMETHOD 'd' /* dense */
+#define METHOD rowRanksWithTies_Dense
 #define MARGIN 'r'
 #define X_TYPE 'r'
 #include "000.templates-gen-matrix.h"
@@ -131,7 +234,7 @@ void rowRanksWithTies_Average_int_drows_dcols(int *x, R_xlen_t nrow, R_xlen_t nc
 #include "000.templates-gen-matrix.h"
 #undef METHOD
 
-#define METHOD colRanksWithTies_Average
+#define METHOD colRanksWithTies_Dense
 #define MARGIN 'c'
 #define X_TYPE 'r'
 #include "000.templates-gen-matrix.h"

--- a/src/rowRanksWithTies_lowlevel_template.h
+++ b/src/rowRanksWithTies_lowlevel_template.h
@@ -13,25 +13,29 @@
   - MARGIN: 'r' (rows) or 'c' (columns).
   - X_TYPE: 'i' or 'r'
   - ANS_TYPE: 'i' or 'r'
-  - TIESMETHOD: '0' (min), '1' (max), 'a' (average)
+  - TIESMETHOD: 'a' (average), 'f' (first), 'l' (last), 'r' (random), '0' (min), '1' (max), 'd' (dense)
 
  Authors:
   Hector Corrada Bravo [HCB]
   Peter Langfelder [PL]
   Henrik Bengtsson [HB]
+  Brian Montgomery [BKM]
  ***********************************************************************/
 #include <Rinternals.h>
 
 #undef RANK
-#if TIESMETHOD == '0'   /* min */
+#if TIESMETHOD == 'a' /* average */
+  #define ANS_TYPE 'r'
+  #define RANK(firstTie, aboveTie) ((double) (firstTie + aboveTie + 1))/2
+#elif TIESMETHOD == '0' /* min */
   #define ANS_TYPE 'i'
   #define RANK(firstTie, aboveTie) firstTie + 1
 #elif TIESMETHOD == '1' /* max */
   #define ANS_TYPE 'i'
   #define RANK(firstTie, aboveTie) aboveTie
-#elif TIESMETHOD == 'a' /* average */
-  #define ANS_TYPE 'r'
-  #define RANK(firstTie, aboveTie) ((double) (firstTie + aboveTie + 1))/2
+#else
+  #define ANS_TYPE 'i' /* dense and other(RANK not used) */
+  #define RANK(firstTie, aboveTie) firstTie + 1
 #endif
 
 /* Expand arguments:
@@ -40,6 +44,7 @@
  */
 #include "000.templates-types.h"
 
+void SHUFFLE_INT(int *array, size_t i, size_t j); /* prototype for use with "random" */
 
 /* Indexing formula to compute the vector index of element j of vector i.
    Should take arguments element, vector, nElements, nVectors. */
@@ -61,7 +66,7 @@ void METHOD_NAME_ROWS_COLS(ARGUMENTS_LIST) {
   R_xlen_t *colOffset;
   R_xlen_t ii, jj, kk, rowIdx;
   int *I;
-  int lastFinite, firstTie, aboveTie;
+  int lastFinite, firstTie, aboveTie, dense_rank_adj;
   int nvalues, nVec;
 
 #ifdef ROWS_TYPE
@@ -150,15 +155,37 @@ void METHOD_NAME_ROWS_COLS(ARGUMENTS_LIST) {
     if (lastFinite > 0) X_QSORT_I(values, I, 1, lastFinite + 1);
 
     // Calculate the ranks.
+    firstTie = 0;
+    aboveTie = 1;
+    dense_rank_adj = 0;
     for (jj=0; jj <= lastFinite;) {
-      firstTie = jj;
+      if (TIESMETHOD == 'd') {
+        dense_rank_adj += (aboveTie - firstTie - 1);
+      }
+      firstTie = jj - dense_rank_adj;
       current = values[jj];
       while ((jj <= lastFinite) && (values[jj] == current)) jj++;
-      aboveTie = jj;
-      // Depending on rank method, get maximum, average, or minimum rank
-      rank = RANK(firstTie, aboveTie);
+      aboveTie = jj - dense_rank_adj;
+      // X_QSORT_I is not stable - ties can be permuted.
+      // This restores the original order.
+      // It might be more efficient to use a stable sort to begin with.
+      if (TIESMETHOD == 'f' || TIESMETHOD == 'l') {
+        R_qsort_int(I, firstTie + 1, aboveTie); /* Function is 1-based */
+      // SHUFFLE_INT randomizes the order.
+      } else if (TIESMETHOD == 'r') {
+        SHUFFLE_INT(I, firstTie, aboveTie - 1);
+      } else {
+        // Get appropriate rank for average, min, max, or dense
+        rank = RANK(firstTie, aboveTie);
+      }
       for (kk=firstTie; kk < aboveTie; kk++) {
-        ans[ ANS_INDEX_OF(I[kk], ii, nrows) ] = rank;
+        if (TIESMETHOD == 'f' || TIESMETHOD == 'r') {
+          ans[ ANS_INDEX_OF(I[kk], ii, nrows) ] = kk + 1;
+        } else if (TIESMETHOD == 'l') {
+          ans[ ANS_INDEX_OF(I[kk], ii, nrows) ] = aboveTie - (kk - firstTie);
+        } else {
+          ans[ ANS_INDEX_OF(I[kk + dense_rank_adj], ii, nrows) ] = rank;
+        }
       }
     }
 

--- a/src/rowRanksWithTies_lowlevel_template.h
+++ b/src/rowRanksWithTies_lowlevel_template.h
@@ -202,6 +202,8 @@ void METHOD_NAME_ROWS_COLS(ARGUMENTS_LIST) {
 
 /***************************************************************************
  HISTORY:
+ 2019-4-23 [BKM]
+  o Added new tiesMethods: first, last, random, and dense.
  2015-06-12 [DJ]
   o Supported subsetted computation.
  2014-11-06 [HB]

--- a/tests/rowRanks.R
+++ b/tests/rowRanks.R
@@ -98,19 +98,7 @@ for (kk in 1:4) {
 
 cat("Consistency checks for dense:\n")
 
-dense_rank <- function(x){
-  ans <- rank(x, na.last = "keep", ties.method = "min")
-  #squeeze the ranks to make them "dense"
-  r <- 2L
-  while (any(ans > r, na.rm = TRUE)) {
-    if (length(ans[ans %in% r]) == 0) {
-      ans[!is.na(ans) & ans > r] <- ans[!is.na(ans) & ans > r] - 1L
-    } else {
-      r <- r + 1L
-    }
-  }
-  ans
-}
+dense_rank <- function(x) match(x, sort(unique(x)))
 
 for (kk in 1:4) {
   cat("Random test #", kk, "\n", sep = "")

--- a/tests/rowRanks.R
+++ b/tests/rowRanks.R
@@ -3,57 +3,135 @@ library("matrixStats")
 set.seed(1)
 
 cat("Consistency checks:\n")
+x <- vector('list', 4)
 for (kk in 1:4) {
-  cat("Random test #", kk, "\n", sep = "")
-
-  # Simulate data in a matrix of any shape
+  
+  # Simulate data in a matrix of any shape - store in list
   dim <- sample(40:80, size = 2L)
   n <- prod(dim)
-  x <- rnorm(n, sd = 10)
-  dim(x) <- dim
-
+  x[[kk]] <- rnorm(n, sd = 10)
+  dim(x[[kk]]) <- dim
+  
   # Add NAs?
   if ((kk %% 4) %in% c(3, 0)) {
     cat("Adding NAs\n")
     nna <- sample(n, size = 1L)
-    x[sample(length(x), size = nna)] <- NA_real_
+    x[[kk]][sample(length(x[[kk]]), size = nna)] <- NA_real_
   }
-
+  
   # Integer or double?
   if ((kk %% 4) %in% c(2, 0)) {
     cat("Coercing to integers\n")
-    storage.mode(x) <- "integer"
+    storage.mode(x[[kk]]) <- "integer"
   }
+} # for (kk ...)
+str(x)
 
-  str(x)
-
-  for (ties in c("max", "min", "average")) {
+for (kk in 1:4) {
+  cat("Random test #", kk, "\n", sep = "")
+  for (ties in c("max", "min", "average", "first", "last")) {
     cat(sprintf("ties.method = %s\n", ties))
     # rowRanks():
-    y1 <- matrixStats::rowRanks(x, ties.method = ties)
-    y2 <- t(apply(x, MARGIN = 1L, FUN = rank, na.last = "keep",
+    y1 <- matrixStats::rowRanks(x[[kk]], ties.method = ties)
+    y2 <- t(apply(x[[kk]], MARGIN = 1L, FUN = rank, na.last = "keep",
                   ties.method = ties))
     stopifnot(identical(y1, y2))
-
-    y3 <- matrixStats::colRanks(t(x), ties.method = ties)
+    
+    y3 <- matrixStats::colRanks(t(x[[kk]]), ties.method = ties)
     stopifnot(identical(y1, y3))
-
+    
     # colRanks():
-    y1 <- matrixStats::colRanks(x, ties.method = ties)
-    y2 <- t(apply(x, MARGIN = 2L, FUN = rank, na.last = "keep",
+    y1 <- matrixStats::colRanks(x[[kk]], ties.method = ties)
+    y2 <- t(apply(x[[kk]], MARGIN = 2L, FUN = rank, na.last = "keep",
                   ties.method = ties))
     stopifnot(identical(y1, y2))
+    
+    y3 <- matrixStats::rowRanks(t(x[[kk]]), ties.method = ties)
+    stopifnot(identical(y1, y3))
+  }
+} # for (kk ...)
 
-    y3 <- matrixStats::rowRanks(t(x), ties.method = ties)
+cat("Consistency checks for random:\n")
+for (kk in 1:4) {
+  cat("Random test #", kk, "\n", sep = "")
+  
+  for (ties in c("random")) {
+    cat(sprintf("ties.method = %s\n", ties))
+    # rowRanks():
+    y1 <- matrixStats::rowRanks(x[[kk]], ties.method = ties)
+    y2min <- t(apply(x[[kk]], MARGIN = 1L, FUN = rank, na.last = "keep",
+                     ties.method = "min"))
+    y2max <- t(apply(x[[kk]], MARGIN = 1L, FUN = rank, na.last = "keep",
+                     ties.method = "max"))
+    stopifnot(all(y1 >= y2min, na.rm = TRUE) && all(y1 <= y2max, na.rm = TRUE))
+    y1list <- Map(function(...) matrixStats::rowRanks(x[[kk]], ties.method = ties), 1:10000)
+    y1mean <- Reduce(`+`, y1list) / length(y1list)
+    y2avg <- t(apply(x[[kk]], MARGIN = 1L, FUN = rank, na.last = "keep",
+                     ties.method = "average"))
+    stopifnot(!(abs(y1mean - y2avg) < 0.1) %in% FALSE)
+    
+    y3min <- matrixStats::colRanks(t(x[[kk]]), ties.method = 'min')
+    y3max <- matrixStats::colRanks(t(x[[kk]]), ties.method = 'max')
+    stopifnot(all(y1 >= y3min, na.rm = TRUE) && all(y1 <= y3max, na.rm = TRUE))
+    y3avg <- matrixStats::colRanks(t(x[[kk]]), ties.method = 'average')
+    stopifnot(!(abs(y1mean - y3avg) < 0.1) %in% FALSE)
+    # colRanks():
+    y1 <- matrixStats::colRanks(x[[kk]], ties.method = ties)
+    y2min <- t(apply(x[[kk]], MARGIN = 2L, FUN = rank, na.last = "keep",
+                     ties.method = "min"))
+    y2max <- t(apply(x[[kk]], MARGIN = 2L, FUN = rank, na.last = "keep",
+                     ties.method = "max"))
+    stopifnot(all(y1 >= y2min, na.rm = TRUE) && all(y1 <= y2max, na.rm = TRUE))
+    y1list <- Map(function(...) matrixStats::colRanks(x[[kk]], ties.method = ties), 1:10000)
+    y1mean <- Reduce(`+`, y1list) / length(y1list)
+    y2avg <- t(apply(x[[kk]], MARGIN = 2L, FUN = rank, na.last = "keep",
+                     ties.method = "average"))
+    stopifnot(!(abs(y1mean - y2avg) < 0.1) %in% FALSE)
+    
+    y3min <- matrixStats::rowRanks(t(x[[kk]]), ties.method = "min")
+    y3max <- matrixStats::rowRanks(t(x[[kk]]), ties.method = "max")
+    stopifnot(all(y1 >= y3min, na.rm = TRUE) && all(y1 <= y3max, na.rm = TRUE))
+    y3avg <- matrixStats::rowRanks(t(x[[kk]]), ties.method = "average")
+    stopifnot(!(abs(y1mean - y3avg) < 0.1) %in% FALSE)
+  }
+} # for (kk ...)
+
+cat("Consistency checks for dense:\n")
+if (!requireNamespace("data.table", quietly = TRUE)) {
+  stop("Package \"data.table\" needed for tests of \"dense\" ties.method to work. Please install it.",
+       call. = FALSE)
+}
+  for (kk in 1:4) {
+  
+  cat("Random test #", kk, "\n", sep = "")
+  for (ties in c("dense")) {
+    cat(sprintf("ties.method = %s\n", ties))
+    # rowRanks():
+    y1 <- matrixStats::rowRanks(x[[kk]], ties.method = ties)
+    y2 <- t(apply(x[[kk]], MARGIN = 1L, FUN = data.table::frank, na.last = "keep",
+                  ties.method = ties))
+    stopifnot(identical(y1, y2))
+    
+    y3 <- matrixStats::colRanks(t(x[[kk]]), ties.method = ties)
+    stopifnot(identical(y1, y3))
+    
+    # colRanks():
+    y1 <- matrixStats::colRanks(x[[kk]], ties.method = ties)
+    y2 <- t(apply(x[[kk]], MARGIN = 2L, FUN = data.table::frank, na.last = "keep",
+                  ties.method = ties))
+    stopifnot(identical(y1, y2))
+    
+    y3 <- matrixStats::rowRanks(t(x[[kk]]), ties.method = ties)
     stopifnot(identical(y1, y3))
   }
 } # for (kk ...)
 
 
+
 ## Exception handling
-x <- matrix(1:12, nrow = 3L)
-y <- try(rowRanks(x, ties.method = "unknown"), silent = TRUE)
+m <- matrix(1:12, nrow = 3L)
+y <- try(rowRanks(m, ties.method = "unknown"), silent = TRUE)
 stopifnot(inherits(y, "try-error"))
 
-y <- try(colRanks(x, ties.method = "unknown"), silent = TRUE)
+y <- try(colRanks(m, ties.method = "unknown"), silent = TRUE)
 stopifnot(inherits(y, "try-error"))


### PR DESCRIPTION
The goal is to be compatible with base::rank
Add ties.method's "first", "last", "random"
Change the order of the ties.method options to match base::rank
So new default ties.method is "average"
Also add "dense" option as in data.table::frank