### PR TITLE
Add logical matrix as a legal input to row|colCumsums. 

### DIFF
--- a/R/rowCumsums.R
+++ b/R/rowCumsums.R
@@ -30,6 +30,7 @@
 #' @export
 rowCumsums <- function(x, rows = NULL, cols = NULL, dim. = dim(x), ...) {
   dim <- as.integer(dim.)
+  if (storage.mode(x) == "logical") storage.mode(x) <- "integer"
   .Call(C_rowCumsums, x, dim, rows, cols, TRUE)
 }
 
@@ -38,6 +39,7 @@ rowCumsums <- function(x, rows = NULL, cols = NULL, dim. = dim(x), ...) {
 #' @export
 colCumsums <- function(x, rows = NULL, cols = NULL, dim. = dim(x), ...) {
   dim <- as.integer(dim.)
+  if (storage.mode(x) == "logical") storage.mode(x) <- "integer"
   .Call(C_rowCumsums, x, dim, rows, cols, FALSE)
 }
 

--- a/tests/rowCumsums.R
+++ b/tests/rowCumsums.R
@@ -12,7 +12,7 @@ rowCumsums_R <- function(x) {
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # With and without some NAs
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-for (mode in c("integer", "double")) {
+for (mode in c("integer", "double", "logical")) {
   for (add_na in c(FALSE, TRUE)) {
     cat("add_na = ", add_na, "\n", sep = "")
 
@@ -38,7 +38,7 @@ for (mode in c("integer", "double")) {
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # All NAs
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-for (mode in c("integer", "double")) {
+for (mode in c("integer", "double", "logical")) {
   x <- matrix(NA_real_, nrow = 20, ncol = 5)
   cat("mode: ", mode, "\n", sep = "")
   storage.mode(x) <- mode
@@ -56,7 +56,7 @@ for (mode in c("integer", "double")) {
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # A 1x1 matrix
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-for (mode in c("integer", "double")) {
+for (mode in c("integer", "double", "logical")) {
   x <- matrix(0, nrow = 1, ncol = 1)
   cat("mode: ", mode, "\n", sep = "")
   storage.mode(x) <- mode


### PR DESCRIPTION
Always returns an integer matrix. This is true even for a 0x0 input.

Add logical matrix to tests (except for 0x0).

See #139 