### PR TITLE
Make sure that colQuantile with type = 7 always returns doubles

### DIFF
--- a/R/rowQuantiles.R
+++ b/R/rowQuantiles.R
@@ -191,7 +191,11 @@ colQuantiles <- function(x, rows = NULL, cols = NULL,
 
   # Allocate result
   na_value <- NA_real_
-  storage.mode(na_value) <- storage.mode(x)
+  if(type != 7){
+    storage.mode(na_value) <- storage.mode(x)
+  }else{
+    storage.mode(na_value) <- "double"
+  }
   q <- matrix(na_value, nrow = ncol, ncol = length(probs))
 
   if (nrow > 0L && ncol > 0L) {
@@ -242,7 +246,6 @@ colQuantiles <- function(x, rows = NULL, cols = NULL,
         }
       }
       
-      storage.mode(q) <- "numeric"
     } else {
       # For each column...
       cols <- seq_len(ncol)


### PR DESCRIPTION
Hi Henrik,
@LTLA opened an issue (https://github.com/const-ae/sparseMatrixStats/issues/11) in `sparseMatrixStats` about some discrepancy between SMS and matrixStats, for `[col|row]Quantiles` if `type = 7` when the input matrix is all `NA_logical`.

This is the only condition where `[col|row]Quantiles(x, type = 7)` returns a logical result:

``` r
library(matrixStats)
mat <- matrix(NA, 10, 10)
typeof(colQuantiles(mat, type = 7, na.rm=FALSE))
#> [1] "logical"

mat <- matrix(c(TRUE, FALSE), 10, 10)
typeof(colQuantiles(mat, type = 7, na.rm=FALSE))
#> [1] "double"
```

<sup>Created on 2020-10-16 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Instead of adapting the behavior of SMS, I think it is easier to fix the behavior in `matrixStats`. What do you think?

Best, Constantin