### PR TITLE
Naming support

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -45,3 +45,5 @@ revdep
 ^[.]check
 ^.*[.]tar[.]gz$
 ^last[.]dump_.*
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 revdep/data.sqlite
 revdep/checks/*
 revdep/library/*
+.Rproj.user

--- a/src/naming.c
+++ b/src/naming.c
@@ -1,0 +1,53 @@
+#include "naming.h"
+void setNames(SEXP vec/* Answer vector*/,SEXP namesVec,R_xlen_t length,void *subscripts,int idxType){
+
+if(length == 0){
+  /* If the targets has length zero, we skip the entire process
+   * which also is the behavior of base::rowSums
+   */
+  return;
+}
+SEXP ansNames;                                                                    
+PROTECT(ansNames = allocVector(STRSXP,length));                                     
+if(idxType == SUBSETTED_ALL){                                                   
+  ansNames = namesVec;                                                  
+}                                                                                 
+else if(idxType == SUBSETTED_INTEGER){
+  Rprintf("Using integer mapping with %d indecies",length);
+  int *typedIdx = subscripts;                                                          
+  R_xlen_t thisIdx;                                                               
+  for(R_xlen_t i = 0; i < length; i++){
+    thisIdx = (typedIdx[i] == NA_INTEGER) ? NA_R_XLEN_T : (R_xlen_t)typedIdx[i]-1;
+    Rprintf("i=%d,Idx=%d",i,thisIdx);
+    if(thisIdx == NA_R_XLEN_T){                                                   
+      SET_STRING_ELT(ansNames,i,NA_STRING);                                       
+    }                                                                             
+    else{                                                                         
+      SEXP eltElement = STRING_ELT(namesVec, thisIdx);                  
+      SET_STRING_ELT(ansNames,i,eltElement);                                      
+    }                                                                             
+  }                                                                               
+}                                                                                 
+else if(idxType == SUBSETTED_REAL){
+  Rprintf("Using floating point mapping");
+  double *typedIdx = subscripts;                                                       
+  R_xlen_t thisIdx;                                                               
+  for(R_xlen_t i = 0; i < length; i++){
+    Rprintf("index=%f",typedIdx);
+    thisIdx = ISNAN(typedIdx[i]) ? NA_R_XLEN_T : (R_xlen_t)typedIdx[i]-1;
+    Rprintf("i=%d,Idx=%d",i,thisIdx);
+    if(thisIdx == NA_R_XLEN_T){                                                   
+      SET_STRING_ELT(ansNames,i,NA_STRING);                                       
+    }                                                                             
+    else{                                                                         
+      SEXP eltElement = STRING_ELT(namesVec, thisIdx);                  
+      SET_STRING_ELT(ansNames,i,eltElement);                                      
+    }                                                                             
+  }                                                                               
+}                                                                                 
+else{                                                                             
+  error("Invalid index type");                                                    
+}                                                                                 
+namesgets(vec,ansNames);                                                          
+UNPROTECT(1);
+}

--- a/src/naming.h
+++ b/src/naming.h
@@ -1,0 +1,7 @@
+#ifndef NAMING_H
+#define NAMING_H
+#include <R.h>
+#include <Rinternals.h>
+#include "000.types.h"
+void setNames(SEXP vec/* Answer vector*/,SEXP namesVec,R_xlen_t length,void *subscripts,int idxType);
+#endif /* NAMING_H */

--- a/tests/rowSums2.R
+++ b/tests/rowSums2.R
@@ -14,35 +14,91 @@ colSums2_R <- function(x, na.rm = FALSE, ...) {
   colSums(x, na.rm = na.rm)
 }
 
+refRownames <- letters[1:3]
+refColnames <- LETTERS[1:3]
+refDimnames <- list(refRownames,refColnames)
 for (mode in c("integer", "logical", "double")) {
-  x <- matrix(-4:4, nrow = 3, ncol = 3)
+  x <- matrix(-4:4, nrow = 3, ncol = 3,dimnames = refDimnames)
   storage.mode(x) <- mode
   if (mode == "double") x <- x + 0.1
  
   y0 <- rowSums_R(x, na.rm = FALSE)
   y1 <- rowSums2(x, na.rm = FALSE)
   stopifnot(all.equal(y1, y0))
+  stopifnot(all.equal(names(y1),names(y0)))
 
   y0 <- colSums2_R(x, na.rm = FALSE)
   y1 <- colSums2(x, na.rm = FALSE)
   stopifnot(all.equal(y1, y0))
+  stopifnot(all.equal(names(y1),names(y0)))
 }
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Special case: Dimnames have NA values
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+cat("Special case: Dimnames have NA values:\n")
+dimnamesWithNA <- list(c("a",NA_character_,"c"),c("A","B",NA_character_))
+x <- matrix(-4:4, nrow = 3, ncol = 3, dimnames = dimnamesWithNA)
+
+y0 <- rowSums_R(x, na.rm = FALSE)
+y1 <- rowSums2(x, na.rm = FALSE)
+stopifnot(all.equal(y1, y0))
+stopifnot(all.equal(names(y1),names(y0)))
+
+y0 <- colSums2_R(x, na.rm = FALSE)
+y1 <- colSums2(x, na.rm = FALSE)
+stopifnot(all.equal(y1, y0))
+stopifnot(all.equal(names(y1),names(y0)))
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Special case: Only rows are named
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+cat("Special case: Only rows are named:\n")
+x <- matrix(-4:4, nrow = 3, ncol = 3,dimnames = list(refRownames,NULL))
+
+y0 <- rowSums_R(x, na.rm = FALSE)
+y1 <- rowSums2(x, na.rm = FALSE)
+stopifnot(all.equal(y1, y0))
+stopifnot(all.equal(names(y1),names(y0)))
+
+y0 <- colSums2_R(x, na.rm = FALSE)
+y1 <- colSums2(x, na.rm = FALSE)
+stopifnot(all.equal(y1, y0))
+stopifnot(all.equal(names(y1),names(y0)))
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Special case: Only columns are named
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+cat("Special case: Only columns are named:\n")
+x <- matrix(-4:4, nrow = 3, ncol = 3,dimnames = list(NULL,refColnames))
+
+y0 <- rowSums_R(x, na.rm = FALSE)
+y1 <- rowSums2(x, na.rm = FALSE)
+stopifnot(all.equal(y1, y0))
+stopifnot(all.equal(names(y1),names(y0)))
+
+y0 <- colSums2_R(x, na.rm = FALSE)
+y1 <- colSums2(x, na.rm = FALSE)
+stopifnot(all.equal(y1, y0))
+stopifnot(all.equal(names(y1),names(y0)))
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Special case: Single-element matrix
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 cat("Special case: Single-element matrix:\n")
 for (mode in c("integer", "logical", "double")) {
-  x <- matrix(1, nrow = 1, ncol = 1)
+  x <- matrix(1, nrow = 1, ncol = 1,dimnames = list("a","A"))
   storage.mode(x) <- mode
 
   y0 <- rowSums_R(x, na.rm = FALSE)
   y1 <- rowSums2(x, na.rm = FALSE)
   stopifnot(all.equal(y1, y0))
+  stopifnot(all.equal(names(y1),names(y0)))
 
   y0 <- colSums2_R(x, na.rm = FALSE)
   y1 <- colSums2(x, na.rm = FALSE)
   stopifnot(all.equal(y1, y0))
+  stopifnot(all.equal(names(y1),names(y0)))
 }
 
 
@@ -51,7 +107,9 @@ for (mode in c("integer", "logical", "double")) {
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 cat("Special case: Empty matrix:\n")
 for (mode in c("integer", "logical", "double")) {
-  x <- matrix(integer(0), nrow = 0, ncol = 0)
+  x <- matrix(integer(0), nrow = 0, ncol = 0, dimnames = list(character(0),character(0)))
+  # No reason to check names here, but we still have to keep in mind that the particular
+  # dimname configuration of the matrix may cause trouble
   storage.mode(x) <- mode
 
   y0 <- rowSums_R(x, na.rm = FALSE)
@@ -69,16 +127,18 @@ for (mode in c("integer", "logical", "double")) {
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 cat("Special case: All NAs:\n")
 for (mode in c("integer", "logical", "double")) {
-  x <- matrix(NA_integer_, nrow = 3, ncol = 3)
+  x <- matrix(NA_integer_, nrow = 3, ncol = 3,dimnames = refDimnames)
   storage.mode(x) <- mode
 
   y0 <- rowSums_R(x, na.rm = TRUE)
   y1 <- rowSums2(x, na.rm = TRUE)
   stopifnot(all.equal(y1, y0))
+  stopifnot(all.equal(names(y1),names(y0)))
 
   y0 <- colSums2_R(x, na.rm = TRUE)
   y1 <- colSums2(x, na.rm = TRUE)
   stopifnot(all.equal(y1, y0))
+  stopifnot(all.equal(names(y1),names(y0)))
 }
 
 
@@ -86,46 +146,50 @@ for (mode in c("integer", "logical", "double")) {
 # Special case: All NaNs
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 cat("Special case: All NaNs:\n")
-x <- matrix(NA_real_, nrow = 3, ncol = 3)
+x <- matrix(NA_real_, nrow = 3, ncol = 3,dimnames = refDimnames)
 
 y0 <- rowSums_R(x, na.rm = TRUE)
 y1 <- rowSums2(x, na.rm = TRUE)
 stopifnot(all.equal(y1, y0))
+stopifnot(all.equal(names(y1),names(y0)))
 
 y0 <- colSums2_R(x, na.rm = TRUE)
 y1 <- colSums2(x, na.rm = TRUE)
 stopifnot(all.equal(y1, y0))
+stopifnot(all.equal(names(y1),names(y0)))
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Special case: All Infs
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 cat("Special case: All Infs:\n")
-x <- matrix(Inf, nrow = 3, ncol = 3)
+x <- matrix(Inf, nrow = 3, ncol = 3,dimnames = refDimnames)
 
 y0 <- rowSums_R(x, na.rm = FALSE)
 y1 <- rowSums2(x, na.rm = FALSE)
 stopifnot(all.equal(y1, y0))
+stopifnot(all.equal(names(y1),names(y0)))
 
 y0 <- colSums2_R(x, na.rm = FALSE)
 y1 <- colSums2(x, na.rm = FALSE)
 stopifnot(all.equal(y1, y0))
-
+stopifnot(all.equal(names(y1),names(y0)))
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Special case: All -Infs
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 cat("Special case: All -Infs:\n")
-x <- matrix(-Inf, nrow = 3, ncol = 3)
+x <- matrix(-Inf, nrow = 3, ncol = 3,dimnames = refDimnames)
 
 y0 <- rowSums_R(x, na.rm = FALSE)
 y1 <- rowSums2(x, na.rm = FALSE)
 stopifnot(all.equal(y1, y0))
+stopifnot(all.equal(names(y1),names(y0)))
 
 y0 <- colSums2_R(x, na.rm = FALSE)
 y1 <- colSums2(x, na.rm = FALSE)
 stopifnot(all.equal(y1, y0))
-
+stopifnot(all.equal(names(y1),names(y0)))
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Special case: Infs and -Infs
@@ -145,8 +209,8 @@ stopifnot(all.equal(y1, y0))
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Special case: NaNs and NAs
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-cat("Special case: Infs and -Infs:\n")
-x <- matrix(c(NaN, NA_real_), nrow = 4, ncol = 4)
+cat("Special case: NaNs and NAs:\n")
+x <- matrix(c(NaN, NA_real_), nrow = 4, ncol = 4, dimnames = list(letters[1:4],LETTERS[1:4]))
 
 y0 <- rowSums(x, na.rm = FALSE)
 str(y0)
@@ -155,6 +219,7 @@ y1 <- rowSums2(x, na.rm = FALSE)
 str(y0)
 stopifnot(all(is.na(y1)), length(unique(y1)) >= 1L)
 stopifnot(all.equal(y1, y0))
+stopifnot(all.equal(names(y1),names(y0)))
 
 y0 <- colSums(x, na.rm = FALSE)
 stopifnot(all(is.na(y0)), length(unique(y0)) == 1L)
@@ -172,15 +237,18 @@ stopifnot(all(is.na(y1)), length(unique(y1)) == 1L)
 # Special case: Integer overflow with ties
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 cat("Special case: Integer overflow with ties:\n")
-x <- matrix(.Machine$integer.max, nrow = 4, ncol = 4)
+fourDimnames <- list(letters[1:4],LETTERS[1:4])
+x <- matrix(.Machine$integer.max, nrow = 4, ncol = 4,dimnames = fourDimnames)
 
 y0 <- rowSums_R(x, na.rm = FALSE)
 y1 <- rowSums2(x, na.rm = FALSE)
 stopifnot(all.equal(y1, y0))
+stopifnot(all.equal(names(y1),names(y0)))
 
 y0 <- colSums2_R(x, na.rm = FALSE)
 y1 <- colSums2(x, na.rm = FALSE)
 stopifnot(all.equal(y1, y0))
+stopifnot(all.equal(names(y1),names(y0)))
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -198,6 +266,7 @@ for (kk in seq_len(n_sims)) {
   n <- prod(dim)
   x <- rnorm(n, sd = 100)
   dim(x) <- dim
+  dimnames(x) <- list(as.character(1:dim[1]),as.character(1:dim[2]))
 
   # Add NAs?
   if ((kk %% 4) %in% c(3, 0)) {
@@ -226,14 +295,18 @@ for (kk in seq_len(n_sims)) {
     y0 <- rowSums_R(x, na.rm = na.rm)
     y1 <- rowSums2(x, na.rm = na.rm)
     stopifnot(all.equal(y1, y0))
+    stopifnot(all.equal(names(y1),names(y0)))
     y2 <- colSums2(t(x), na.rm = na.rm)
     stopifnot(all.equal(y2, y0))
+    stopifnot(all.equal(names(y2),names(y0)))
   
     # colSums2():
     y0 <- colSums2_R(x, na.rm = na.rm)
     y1 <- colSums2(x, na.rm = na.rm)
     stopifnot(all.equal(y1, y0))
+    stopifnot(all.equal(names(y1),names(y0)))
     y2 <- rowSums2(t(x), na.rm = na.rm)
     stopifnot(all.equal(y2, y0))
+    stopifnot(all.equal(names(y2),names(y0)))
   }
 } # for (kk ...)

--- a/tests/rowSums2_subset.R
+++ b/tests/rowSums2_subset.R
@@ -19,17 +19,18 @@ colSums2_R <- function(x, na.rm = FALSE, ...) {
 # Subsetted tests
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 source("utils/validateIndicesFramework.R")
-x <- matrix(runif(6 * 6, min = -3, max = 3), nrow = 6, ncol = 6)
+refDimnames <- list(letters[1:6],LETTERS[1:6])
+x <- matrix(runif(6 * 6, min = -3, max = 3), nrow = 6, ncol = 6,dimnames = refDimnames)
 storage.mode(x) <- "integer"
 for (rows in index_cases) {
   for (cols in index_cases) {
     for (na.rm in c(TRUE, FALSE)) {
       validateIndicesTestMatrix(x, rows, cols,
                                 ftest = rowSums2, fsure = rowSums2_R,
-                                na.rm = na.rm)
+                                na.rm = na.rm,useNames = TRUE,debug = TRUE)
       validateIndicesTestMatrix(x, rows, cols,
                                 fcoltest = colSums2, fsure = rowSums2_R,
-                                na.rm = na.rm)
+                                na.rm = na.rm, useNames = TRUE,debug = TRUE)
     }
   }
 }

--- a/tests/utils/validateIndicesFramework.R
+++ b/tests/utils/validateIndicesFramework.R
@@ -41,12 +41,11 @@ validateIndicesTestVector_w <- function(x, w, idxs, ftest, fsure,
 }
 
 validateIndicesTestMatrix <- function(x, rows, cols, ftest, fcoltest, fsure,
-                                      debug = FALSE, ...) {
+                                      debug = FALSE,useNames = FALSE, ...) {
   if (debug) {
     cat(sprintf("rows=%s; type=%s\n", toString(rows), toString(typeof(rows))))
     cat(sprintf("cols=%s; type=%s\n", toString(cols), toString(typeof(cols))))
   }
-
   suppressWarnings({
     if (missing(fcoltest)) {
       actual <- tryCatch(ftest(x, rows = rows, cols = cols, ...),
@@ -70,7 +69,10 @@ validateIndicesTestMatrix <- function(x, rows, cols, ftest, fcoltest, fsure,
   if (debug) cat(sprintf("actual=%s\nexpect=%s\n",
                          toString(actual), toString(expect)))
 
-  stopifnot(all.equal(actual, expect))
+  stopifnot(all.equal(unname(actual), unname(expect)))
+  if (debug && useNames) cat(sprintf("namesActual=%s\nnamesExpect=%s\n",
+                         toString(names(actual)), toString(names(expect))))
+  if (useNames) stopifnot(all.equal(names(actual), names(expect)))
 }
 
 validateIndicesTestMatrix_w <- function(x, w, rows, cols, ftest,


### PR DESCRIPTION
As we dicussed yesterday at issue #190, you were worried that mimicing the behavior of `base::rowSums`, returning the rownames in the results would result in a performance overhead. I have now spent the last two days resolving the problem, and created an implementation touching only the C-code. At the time being, I have only implemented the feature for `rowSums2` (and consequently for `colSums2`), but expanding the solution to the rest of the family should be straight-forward. I have tested the package and modified the tests to check whether the names are correct. I leave it to you to benchmark the modifications, but here is what I would expect to happen:

* For unnamed arguments the modified version should barely give any overhead at all. This is due to the fact that the only overhead is a quick check of whether a relevant dimname of the input exists.
* For named arguments which pick all indecies among the leading dimension (rows for `rowSums2` and columns for `colSums2`),  we can more or less [copy the pointer for the name attribute directly](https://github.com/wch/r-source/blob/62b5411eed1b87bac779f1a67ab8384b75dc64ab/src/main/attrib.c#L941), reducing the overhead to a small and constant number of instructions.
* For named arguments which pick a subset of the indecies among the leading dimension, we will have overhead from iterating over these indecies and subsequent extraction and casting. Still, I think the overhead will we slight.

Also, I notice that the package installed size of the package exceeds the recommended limit of 10 MB and that some of the function factory macros are hard to read. You could migitate this problem by writing a custom version of `validateIndecies` (in the C version of course) which always coerse the data under `ansNidxs` to `R_xlen_t` in the case of `SUBSETTED_INTEGER` and `SUBSETTED_REAL`, leaving the `subsettedType` parameter superflous. For functions like `rowSums2`, the coersion to `R_xlen_t` must be done anyway. In the case of `SUBSETTED_ALL`, a `NULL` pointer is returned, making it easy to deal with this case separately.