### PR TITLE
Proof of concept optimization when both rows and cols are unspecified

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -30,6 +30,7 @@ revdep
 ^covr-utils.R$
 ^[.]covr[.]R$
 ^[.]covr[.]rds$
+scratch.R
 
 #----------------------------
 # R related
@@ -51,3 +52,5 @@ revdep
 ^last[.]dump_.*
 ^docs
 ^pkgdown
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ revdep/cache
 revdep/checks
 revdep/library
 docs
+.Rproj.user
+scratch.R

--- a/src/rowSums2_lowlevel_template.h
+++ b/src/rowSums2_lowlevel_template.h
@@ -35,8 +35,7 @@ void CONCAT_MACROS(rowSums2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t
   /* Pre-calculate the column offsets */
   if (nocols) {
     colOffset = NULL;
-  }
-  else {
+  } else {
     colOffset = (R_xlen_t *) R_alloc(ncols, sizeof(R_xlen_t));
     if (byrow) {
       for (jj=0; jj < ncols; jj++)
@@ -49,6 +48,7 @@ void CONCAT_MACROS(rowSums2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t
 
   for (ii=0; ii < nrows; ii++) {
     R_xlen_t rowIdx;
+    
     if (norows) {
       /* ii and ncols cannot be NA-values, so we do not need R_INDEX_OP */
       rowIdx = byrow ? ii : ii*ncol;
@@ -59,7 +59,7 @@ void CONCAT_MACROS(rowSums2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t
     sum = 0.0;
 
     for (jj=0; jj < ncols; jj++) {
-      if (norows && nocols){
+      if (norows && nocols) {
         /*
          * In this special case, we can eliminate
          * the possibility of having NA indicies
@@ -67,8 +67,7 @@ void CONCAT_MACROS(rowSums2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t
         if (byrow) idx = rowIdx + jj*nrow;
         else idx = rowIdx + jj;
         value = x[idx];
-      }
-      else {
+      } else {
         if (nocols) {
             if (byrow) idx = R_INDEX_OP(rowIdx, +, jj*nrow);
             else idx = R_INDEX_OP(rowIdx, +, jj);
@@ -77,6 +76,7 @@ void CONCAT_MACROS(rowSums2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t
         }
         value = R_INDEX_GET(x, idx, X_NA);
       }
+      
   #if X_TYPE == 'i'
       if (!X_ISNAN(value)) {
         sum += (LDOUBLE)value;

--- a/src/rowSums2_lowlevel_template.h
+++ b/src/rowSums2_lowlevel_template.h
@@ -33,7 +33,7 @@ void CONCAT_MACROS(rowSums2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t
   if (rows == NULL) { norows = 1; } else { norows = 0; }
 
   /* Pre-calculate the column offsets */
-  if (cols == NULL) {
+  if (nocols) {
     colOffset = NULL;
   }
   else {
@@ -50,7 +50,8 @@ void CONCAT_MACROS(rowSums2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t
   for (ii=0; ii < nrows; ii++) {
     R_xlen_t rowIdx;
     if (norows) {
-      rowIdx = byrow ? ii : R_INDEX_OP(ii, *, ncol);
+      /* ii and ncols cannot be NA-values, so we do not need R_INDEX_OP */
+      rowIdx = byrow ? ii : ii*ncol;
     } else {
       rowIdx = byrow ? rows[ii] : R_INDEX_OP(rows[ii], *, ncol);
     }
@@ -58,13 +59,24 @@ void CONCAT_MACROS(rowSums2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t
     sum = 0.0;
 
     for (jj=0; jj < ncols; jj++) {
-      if (nocols) {
-        if (byrow) idx = R_INDEX_OP(rowIdx, +, jj*nrow);
-        else idx = R_INDEX_OP(rowIdx, +, jj);
-      } else {
-        idx = R_INDEX_OP(rowIdx, +, colOffset[jj]);
+      if (norows && nocols){
+        /*
+         * In this special case, we can eliminate
+         * the possibility of having NA indicies
+         */
+        if (byrow) idx = rowIdx + jj*nrow;
+        else idx = rowIdx + jj;
+        value = x[idx];
       }
-      value = R_INDEX_GET(x, idx, X_NA);
+      else {
+        if (nocols) {
+            if (byrow) idx = R_INDEX_OP(rowIdx, +, jj*nrow);
+            else idx = R_INDEX_OP(rowIdx, +, jj);
+          } else {
+            idx = R_INDEX_OP(rowIdx, +, colOffset[jj]);
+        }
+        value = R_INDEX_GET(x, idx, X_NA);
+      }
   #if X_TYPE == 'i'
       if (!X_ISNAN(value)) {
         sum += (LDOUBLE)value;


### PR DESCRIPTION
From the definitions of `R_INDEX_OP` and `R_INDEX_GET`, I see that these macros check both arguments for NA-values. In the cases we know that none of the operands are NA, we can avoid wasting CPU cycles on this checking. In this case, I have modified `rowSums2()` to skip checking for index NA values when neither row nor col subsets are provided. From my own tests, I have registered a performance boost and would like you to try it out as well. If implemented consistently, we could probably mitigate most of issue #212.