### PR TITLE
rowRanks rewrite

### DIFF
--- a/src/rowMedians_lowlevel_template.h
+++ b/src/rowMedians_lowlevel_template.h
@@ -66,7 +66,7 @@ void CONCAT_MACROS(rowMedians, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen
       colOffset = (R_xlen_t *) R_alloc(ncols, sizeof(R_xlen_t));
       if (byrow) {
           for (jj=0; jj < ncols; jj++)
-              if(!rowsHasNA && !colsHasNA){
+              if (!rowsHasNA && !colsHasNA) {
                   colOffset[jj] = cols[jj] * nrow;
               }
               else{

--- a/src/rowRanksWithTies.c
+++ b/src/rowRanksWithTies.c
@@ -66,340 +66,80 @@ SEXP rowRanksWithTies(SEXP x, SEXP dim, SEXP rows, SEXP cols, SEXP tiesMethod, S
 
   /* Double matrices are more common to use. */
   if (isReal(x)) {
-    if (byrow) {
       switch (tiesmethod) {
         case 1:
           PROTECT(ans = allocMatrix(REALSXP, nrows, ncols));
-          rowRanksWithTies_Average_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, REAL(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
+          rowRanksWithTies_Average_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, byrow, REAL(ans));
           break;
         case 2:
           PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          rowRanksWithTies_First_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
+          rowRanksWithTies_First_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, byrow, INTEGER(ans));
           break;
         case 3:
           PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          rowRanksWithTies_Last_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
+          rowRanksWithTies_Last_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, byrow, INTEGER(ans));
           break;
         case 4:
           PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
           GetRNGstate();
-          rowRanksWithTies_Random_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
+          rowRanksWithTies_Random_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, byrow, INTEGER(ans));
           PutRNGstate();
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
           break;
         case 5:
           PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          rowRanksWithTies_Max_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
+          rowRanksWithTies_Max_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, byrow, INTEGER(ans));
           break;
         case 6:
           PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          rowRanksWithTies_Min_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
+          rowRanksWithTies_Min_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, byrow, INTEGER(ans));
           break;
         case 7:
           PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          rowRanksWithTies_Dense_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
+          rowRanksWithTies_Dense_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, byrow, INTEGER(ans));
           break;
       } /* switch */
-    } else {
-      switch (tiesmethod) {
-        case 1:
-          PROTECT(ans = allocMatrix(REALSXP, nrows, ncols));
-          colRanksWithTies_Average_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, REAL(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
-          break;
-        case 2:
-          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          colRanksWithTies_First_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
-          break;
-        case 3:
-          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          colRanksWithTies_Last_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
-          break;
-        case 4:
-          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          GetRNGstate();
-          colRanksWithTies_Random_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          PutRNGstate();
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
-          break;
-        case 5:
-          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          colRanksWithTies_Max_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
-          break;
-        case 6:
-          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          colRanksWithTies_Min_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
-          break;
-        case 7:
-          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          colRanksWithTies_Dense_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
-          break;
-      } /* switch */
-    }
   } else if (isInteger(x)) {
-    if (byrow) {
       switch (tiesmethod) {
         case 1:
           PROTECT(ans = allocMatrix(REALSXP, nrows, ncols));
-          rowRanksWithTies_Average_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, REAL(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
+          rowRanksWithTies_Average_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, byrow, REAL(ans));
           break;
         case 2:
           PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          rowRanksWithTies_First_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
+          rowRanksWithTies_First_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, byrow, INTEGER(ans));
           break;
         case 3:
           PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          rowRanksWithTies_Last_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
+          rowRanksWithTies_Last_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, byrow, INTEGER(ans));
           break;
         case 4:
           PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
           GetRNGstate();
-          rowRanksWithTies_Random_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
+          rowRanksWithTies_Random_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, byrow, INTEGER(ans));
           PutRNGstate();
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
           break;
         case 5:
           PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          rowRanksWithTies_Max_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
+          rowRanksWithTies_Max_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, byrow, INTEGER(ans));
           break;
         case 6:
           PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          rowRanksWithTies_Min_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
+          rowRanksWithTies_Min_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, byrow, INTEGER(ans));
           break;
         case 7:
           PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          rowRanksWithTies_Dense_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
+          rowRanksWithTies_Dense_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, byrow, INTEGER(ans));
           break;
       } /* switch */
-    } else {
-      switch (tiesmethod) {
-        case 1:
-          PROTECT(ans = allocMatrix(REALSXP, nrows, ncols));
-          colRanksWithTies_Average_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, REAL(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
-          break;
-        case 2:
-          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          colRanksWithTies_First_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
-          break;
-        case 3:
-          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          colRanksWithTies_Last_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
-          break;
-        case 4:
-          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          GetRNGstate();
-          colRanksWithTies_Random_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          PutRNGstate();
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
-          break;
-        case 5:
-          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          colRanksWithTies_Max_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
-          break;
-        case 6:
-          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          colRanksWithTies_Min_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
-          break;
-        case 7:
-          PROTECT(ans = allocMatrix(INTSXP, nrows, ncols));
-          colRanksWithTies_Dense_int(INTEGER(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, INTEGER(ans));
-          if (usenames != NA_LOGICAL && usenames) {
-            SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
-            if (dimnames != R_NilValue) {
-              setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
-            }
-          }
-          UNPROTECT(1);
-          break;
-      } /* switch */
-    }
   }
   
-  UNPROTECT(1); /* PROTECT(dim = ...) */
+  if (usenames != NA_LOGICAL && usenames) {
+    SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
+    if (dimnames != R_NilValue) {
+      setDimnames(ans, dimnames, nrows, crows, ncols, ccols, FALSE);
+    }
+  }
+  UNPROTECT(2); /* PROTECT(dim = ...) and PROTECT(ans = allocMarix(...))*/
 
   return(ans);
 } // rowRanksWithTies()

--- a/src/rowRanksWithTies_lowlevel.h
+++ b/src/rowRanksWithTies_lowlevel.h
@@ -5,14 +5,13 @@
 /*
 Native API (dynamically generated via macros):
  
-void rowRanksWithTies_Min_dbl(double *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t *rows, R_xlen_t Rf_nrows, R_xlen_t *cols, R_xlen_t Rf_ncols, int *ans)
-void rowRanksWithTies_Min_int(int *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t *rows, R_xlen_t Rf_nrows, R_xlen_t *cols, R_xlen_t Rf_ncols, int *ans)
-void rowRanksWithTies_Max_dbl(double *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t *rows, R_xlen_t Rf_nrows, R_xlen_t *cols, R_xlen_t Rf_ncols, int *ans)
-void rowRanksWithTies_Max_int(int *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t *rows, R_xlen_t Rf_nrows, R_xlen_t *cols, R_xlen_t Rf_ncols, int *ans) 
-void rowRanksWithTies_Min_dbl(double *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t *rows, R_xlen_t Rf_nrows, R_xlen_t *cols, R_xlen_t Rf_ncols, int *ans)
-void rowRanksWithTies_Average_int(int *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t *rows, R_xlen_t Rf_nrows, R_xlen_t *cols, R_xlen_t Rf_ncols, int *ans) 
-void rowRanksWithTies_Min_dbl(double *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t *rows, R_xlen_t Rf_nrows, R_xlen_t *cols, R_xlen_t Rf_ncols, int *ans)
-void rowRanksWithTies_Average_int(int *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t *rows, R_xlen_t Rf_nrows, R_xlen_t *cols, R_xlen_t Rf_ncols, int *ans)
+void rowRanksWithTies_Min_dbl(double *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t *rows, R_xlen_t Rf_nrows, R_xlen_t *cols, R_xlen_t Rf_ncols, int byrow, int *ans)
+void rowRanksWithTies_Min_int(int *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t *rows, R_xlen_t Rf_nrows, R_xlen_t *cols, R_xlen_t Rf_ncols, int byrow, int *ans)
+void rowRanksWithTies_Max_dbl(double *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t *rows, R_xlen_t Rf_nrows, R_xlen_t *cols, R_xlen_t Rf_ncols, int byrow, int *ans)
+void rowRanksWithTies_Max_int(int *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t *rows, R_xlen_t Rf_nrows, R_xlen_t *cols, R_xlen_t Rf_ncols, int byrow, int *ans) 
+void rowRanksWithTies_Min_dbl(double *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t *rows, R_xlen_t Rf_nrows, R_xlen_t *cols, R_xlen_t Rf_ncols, int byrow, int *ans)
+void rowRanksWithTies_Average_int(int *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t *rows, R_xlen_t Rf_nrows, R_xlen_t *cols, R_xlen_t Rf_ncols, int byrow, double *ans) 
+void rowRanksWithTies_Average_dbl(double *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t *rows, R_xlen_t Rf_nrows, R_xlen_t *cols, R_xlen_t Rf_ncols, int byrow, double *ans)
 */
 
 /*****************************************************************
@@ -20,28 +19,15 @@ void rowRanksWithTies_Average_int(int *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t
  *****************************************************************/
 #define TIESMETHOD 'a' /* average */
 #define METHOD rowRanksWithTies_Average
-#define MARGIN 'r'
 #define X_TYPE 'r'
 #include "rowRanksWithTies_lowlevel_template.h"
 #include "000.templates-types_undef.h"
 
-#define MARGIN 'r'
 #define X_TYPE 'i'
 #include "rowRanksWithTies_lowlevel_template.h"
 #include "000.templates-types_undef.h"
 #undef METHOD
 
-#define METHOD colRanksWithTies_Average
-#define MARGIN 'c'
-#define X_TYPE 'r'
-#include "rowRanksWithTies_lowlevel_template.h"
-#include "000.templates-types_undef.h"
-
-#define MARGIN 'c'
-#define X_TYPE 'i'
-#include "rowRanksWithTies_lowlevel_template.h" 
-#include "000.templates-types_undef.h"
-#undef METHOD
 #undef TIESMETHOD
 
 
@@ -50,28 +36,15 @@ void rowRanksWithTies_Average_int(int *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t
  *****************************************************************/
 #define TIESMETHOD 'f' /* first */
 #define METHOD rowRanksWithTies_First
-#define MARGIN 'r'
 #define X_TYPE 'r'
 #include "rowRanksWithTies_lowlevel_template.h" 
 #include "000.templates-types_undef.h"
 
-#define MARGIN 'r'
 #define X_TYPE 'i'
 #include "rowRanksWithTies_lowlevel_template.h" 
 #include "000.templates-types_undef.h"
 #undef METHOD
 
-#define METHOD colRanksWithTies_First
-#define MARGIN 'c'
-#define X_TYPE 'r'
-#include "rowRanksWithTies_lowlevel_template.h" 
-#include "000.templates-types_undef.h"
-
-#define MARGIN 'c'
-#define X_TYPE 'i'
-#include "rowRanksWithTies_lowlevel_template.h" 
-#include "000.templates-types_undef.h"
-#undef METHOD
 #undef TIESMETHOD
 
 
@@ -80,28 +53,15 @@ void rowRanksWithTies_Average_int(int *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t
  *****************************************************************/
 #define TIESMETHOD 'l' /* last */
 #define METHOD rowRanksWithTies_Last
-#define MARGIN 'r'
 #define X_TYPE 'r'
 #include "rowRanksWithTies_lowlevel_template.h" 
 #include "000.templates-types_undef.h"
 
-#define MARGIN 'r'
 #define X_TYPE 'i'
 #include "rowRanksWithTies_lowlevel_template.h"
 #include "000.templates-types_undef.h"
 #undef METHOD
 
-#define METHOD colRanksWithTies_Last
-#define MARGIN 'c'
-#define X_TYPE 'r'
-#include "rowRanksWithTies_lowlevel_template.h" 
-#include "000.templates-types_undef.h"
-
-#define MARGIN 'c'
-#define X_TYPE 'i'
-#include "rowRanksWithTies_lowlevel_template.h" 
-#include "000.templates-types_undef.h"
-#undef METHOD
 #undef TIESMETHOD
 
 
@@ -110,28 +70,15 @@ void rowRanksWithTies_Average_int(int *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t
  *****************************************************************/
 #define TIESMETHOD 'r' /* random */
 #define METHOD rowRanksWithTies_Random
-#define MARGIN 'r'
 #define X_TYPE 'r'
 #include "rowRanksWithTies_lowlevel_template.h" 
 #include "000.templates-types_undef.h"
 
-#define MARGIN 'r'
 #define X_TYPE 'i'
 #include "rowRanksWithTies_lowlevel_template.h" 
 #include "000.templates-types_undef.h"
 #undef METHOD
 
-#define METHOD colRanksWithTies_Random
-#define MARGIN 'c'
-#define X_TYPE 'r'
-#include "rowRanksWithTies_lowlevel_template.h" 
-#include "000.templates-types_undef.h"
-
-#define MARGIN 'c'
-#define X_TYPE 'i'
-#include "rowRanksWithTies_lowlevel_template.h" 
-#include "000.templates-types_undef.h"
-#undef METHOD
 #undef TIESMETHOD
 
 
@@ -140,28 +87,15 @@ void rowRanksWithTies_Average_int(int *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t
  *****************************************************************/
 #define TIESMETHOD '0' /* min */
 #define METHOD rowRanksWithTies_Min
-#define MARGIN 'r'
 #define X_TYPE 'r'
 #include "rowRanksWithTies_lowlevel_template.h" 
 #include "000.templates-types_undef.h"
 
-#define MARGIN 'r'
 #define X_TYPE 'i'
 #include "rowRanksWithTies_lowlevel_template.h" 
 #include "000.templates-types_undef.h"
 #undef METHOD
 
-#define METHOD colRanksWithTies_Min
-#define MARGIN 'c'
-#define X_TYPE 'r'
-#include "rowRanksWithTies_lowlevel_template.h" 
-#include "000.templates-types_undef.h"
-
-#define MARGIN 'c'
-#define X_TYPE 'i'
-#include "rowRanksWithTies_lowlevel_template.h" 
-#include "000.templates-types_undef.h"
-#undef METHOD
 #undef TIESMETHOD
 
 
@@ -170,28 +104,15 @@ void rowRanksWithTies_Average_int(int *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t
  *****************************************************************/
 #define TIESMETHOD '1' /* max */
 #define METHOD rowRanksWithTies_Max
-#define MARGIN 'r'
 #define X_TYPE 'r'
 #include "rowRanksWithTies_lowlevel_template.h" 
 #include "000.templates-types_undef.h"
 
-#define MARGIN 'r'
 #define X_TYPE 'i'
 #include "rowRanksWithTies_lowlevel_template.h" 
 #include "000.templates-types_undef.h"
 #undef METHOD
 
-#define METHOD colRanksWithTies_Max
-#define MARGIN 'c'
-#define X_TYPE 'r'
-#include "rowRanksWithTies_lowlevel_template.h" 
-#include "000.templates-types_undef.h"
-
-#define MARGIN 'c'
-#define X_TYPE 'i'
-#include "rowRanksWithTies_lowlevel_template.h" 
-#include "000.templates-types_undef.h"
-#undef METHOD
 #undef TIESMETHOD
 
 
@@ -200,26 +121,13 @@ void rowRanksWithTies_Average_int(int *x, R_xlen_t nrow, R_xlen_t ncol, R_xlen_t
  *****************************************************************/
 #define TIESMETHOD 'd' /* dense */
 #define METHOD rowRanksWithTies_Dense
-#define MARGIN 'r'
 #define X_TYPE 'r'
 #include "rowRanksWithTies_lowlevel_template.h" 
 #include "000.templates-types_undef.h"
 
-#define MARGIN 'r'
 #define X_TYPE 'i'
 #include "rowRanksWithTies_lowlevel_template.h" 
 #include "000.templates-types_undef.h"
 #undef METHOD
 
-#define METHOD colRanksWithTies_Dense
-#define MARGIN 'c'
-#define X_TYPE 'r'
-#include "rowRanksWithTies_lowlevel_template.h" 
-#include "000.templates-types_undef.h"
-
-#define MARGIN 'c'
-#define X_TYPE 'i'
-#include "rowRanksWithTies_lowlevel_template.h" 
-#include "000.templates-types_undef.h"
-#undef METHOD
 #undef TIESMETHOD

--- a/src/rowRanksWithTies_lowlevel_template.h
+++ b/src/rowRanksWithTies_lowlevel_template.h
@@ -10,7 +10,6 @@
    template to work as intended.
 
   - METHOD_NAME: the name of the resulting function
-  - MARGIN: 'r' (rows) or 'c' (columns).
   - X_TYPE: 'i' or 'r'
   - ANS_TYPE: 'i' or 'r'
   - TIESMETHOD: 'a' (average), 'f' (first), 'l' (last), 'r' (random), '0' (min), '1' (max), 'd' (dense)
@@ -99,11 +98,11 @@ void CONCAT_MACROS(METHOD, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t n
   I = (int *) R_alloc(nvalues, sizeof(int));
 
   for (ii=0; ii < nVec; ii++) {
-  if (byrow) {
-    rowIdx = ((rows == NULL) ? (ii) : rows[ii]);
-  } else {
-    rowIdx = R_INDEX_OP(((cols == NULL) ? (ii) : cols[ii]), *, nrow, colsHasNA, 0);
-  }
+    if (byrow) {
+      rowIdx = ((rows == NULL) ? (ii) : rows[ii]);
+    } else {
+      rowIdx = R_INDEX_OP(((cols == NULL) ? (ii) : cols[ii]), *, nrow, colsHasNA, 0);
+    }
     lastFinite = nvalues-1;
 
     /* Put the NA/NaN elements at the end of the vector and update
@@ -113,6 +112,8 @@ void CONCAT_MACROS(METHOD, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t n
        there are missing values. /PL (2012-12-14)
     */
     for (jj = 0; jj <= lastFinite; jj++) {
+      Rprintf("jj=%d\n", jj);
+      Rprintf("lastFinite=%d\n", lastFinite);
       /*
        * Checking for the colsHasNA when we already have to check colsHasNA || rowsHasNA
        * is indeed useless, but for keeping the code ideomatic, we still do it
@@ -123,13 +124,16 @@ void CONCAT_MACROS(METHOD, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t n
       } else {
         tmp = R_INDEX_GET(x, R_INDEX_OP(rowIdx, +, colOffset[jj], colsHasNA, rowsHasNA), X_NA, colsHasNA || rowsHasNA);
       }
+      Rprintf("tmp=%d\n",tmp);
       
       if (X_ISNAN(tmp)) {
         while (lastFinite > jj && X_ISNAN(R_INDEX_GET(x, 
                                                       R_INDEX_OP(rowIdx,+,colOffset[lastFinite], byrow ? rowsHasNA : colsHasNA, byrow ? colsHasNA : rowsHasNA),
                                                       X_NA, colsHasNA || rowsHasNA))) {
+          
           I[lastFinite] = lastFinite;
           lastFinite--;
+          Rprintf("lastFinite=%d\n", lastFinite);
         }
 
         I[lastFinite] = jj;
@@ -143,10 +147,11 @@ void CONCAT_MACROS(METHOD, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t n
         I[jj] = jj;
         values[ jj ] = tmp;
       }
+      Rprintf("lastFinite=%d\n",lastFinite);
     } /* for (jj ...) */
 
    // Diagnostic print-outs
-   /*
+   
 
     Rprintf("Swapped vector:\n");
     for (jj=0; jj < nvalues; jj++)
@@ -160,7 +165,6 @@ void CONCAT_MACROS(METHOD, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t n
       Rprintf(" %d,", I[jj]);
       if (((jj+1) % 5==0) || (jj==nvalues-1)) Rprintf("\n");
     }
-    */
 
 
     // This will sort the data in increasing order and use the I vector to keep track of the original
@@ -234,17 +238,19 @@ void CONCAT_MACROS(METHOD, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t n
         }
       }
     }
-
+    
+    
     // At this point jj = lastFinite + 1, no need to re-initialize again.
     for (; jj < nvalues; jj++) {
       if (byrow) {
+        Rprintf("idx=%d\n",ii + I[jj]*nrows);
         ans[ii + I[jj]*nrows] = ANS_NA;
       } else{
         ans[I[jj] + ii*nrows] = ANS_NA;
       }
     }
 
-    // Rprintf("\n");
+    Rprintf("\n");
   }
 }
 

--- a/src/rowRanksWithTies_lowlevel_template.h
+++ b/src/rowRanksWithTies_lowlevel_template.h
@@ -18,7 +18,8 @@
   Hector Corrada Bravo [HCB]
   Peter Langfelder [PL]
   Henrik Bengtsson [HB]
-  Brian Montgomery [BKM]
+  Brian Montgomery 
+  Jakob Peder Pettersen [JPP]
  ***********************************************************************/
 #include <Rinternals.h>
 
@@ -71,13 +72,17 @@ void CONCAT_MACROS(METHOD, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t n
   
     /* Pre-calculate the column offsets */
     colOffset = (R_xlen_t *) R_alloc(ncols, sizeof(R_xlen_t));
-    if (cols == NULL) {
-      for (jj=0; jj < ncols; jj++)
-        colOffset[jj] = R_INDEX_OP(jj, *, nrow, 0, 0);
-    } else {
-      for (jj=0; jj < ncols; jj++)
-        colOffset[jj] = R_INDEX_OP(cols[jj], *, nrow, colsHasNA, 0);
-    }
+      for (jj=0; jj < ncols; jj++) {
+        if (nocols) {
+        colOffset[jj] = jj * nrow;
+        } else {
+          if (!colsHasNA) {
+            colOffset[jj] = cols[jj] * nrow;
+          } else {
+            colOffset[jj] = R_INDEX_OP(cols[jj], *, nrow, 1, 0);
+          } 
+        }
+      }
 
   } else {
     nvalues = nrows;
@@ -85,14 +90,16 @@ void CONCAT_MACROS(METHOD, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t n
   
     /* Pre-calculate the column offsets */
     colOffset = (R_xlen_t *) R_alloc(nrows, sizeof(R_xlen_t));
-    if (rows == NULL) {
-      for (jj=0; jj < nrows; jj++)
+    
+    for (jj=0; jj < nrows; jj++) {
+      if (norows) {
         colOffset[jj] = jj;
-    } else {
-      for (jj=0; jj < nrows; jj++)
+      } else {
         colOffset[jj] = rows[jj];
+      }
     }
-  }
+  } // if (byrow)
+    
   
 
   values = (X_C_TYPE *) R_alloc(nvalues, sizeof(X_C_TYPE));

--- a/src/rowRanksWithTies_lowlevel_template.h
+++ b/src/rowRanksWithTies_lowlevel_template.h
@@ -127,10 +127,20 @@ void CONCAT_MACROS(METHOD, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t n
       Rprintf("tmp=%d\n",tmp);
       
       if (X_ISNAN(tmp)) {
-        while (lastFinite > jj && X_ISNAN(R_INDEX_GET(x, 
-                                                      R_INDEX_OP(rowIdx,+,colOffset[lastFinite], byrow ? rowsHasNA : colsHasNA, byrow ? colsHasNA : rowsHasNA),
-                                                      X_NA, colsHasNA || rowsHasNA))) {
-          
+        while (lastFinite > jj) {
+          Rprintf("rowIdx=%d\n",rowIdx);
+          Rprintf("offset=%d\n",colOffset[lastFinite]);
+          /*
+           * BEWARE: Macro argument containing conditionals must be enclosed within parenthesis.
+           * Otherwise, it will interfere with how the macro is evaluated
+           */
+          R_xlen_t lastFinite_idx = R_INDEX_OP(rowIdx,+,colOffset[lastFinite], (byrow ? rowsHasNA : colsHasNA), (byrow ? colsHasNA : rowsHasNA));
+          Rprintf("lastFinite_idx=%d\n",lastFinite_idx);
+          ANS_C_TYPE lastFinite_val = R_INDEX_GET(x,lastFinite_idx,X_NA, colsHasNA || rowsHasNA);
+          Rprintf("lastFinite_val=%d\n",lastFinite_val);
+          if (!X_ISNAN(lastFinite_val)) {
+            break;
+          }
           I[lastFinite] = lastFinite;
           lastFinite--;
           Rprintf("lastFinite=%d\n", lastFinite);
@@ -139,7 +149,7 @@ void CONCAT_MACROS(METHOD, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t n
         I[lastFinite] = jj;
         I[jj] = lastFinite;
         values[ jj ] = R_INDEX_GET(x, 
-                                   R_INDEX_OP(rowIdx,+,colOffset[lastFinite], byrow ? rowsHasNA : colsHasNA, byrow ? colsHasNA : rowsHasNA),
+                                   R_INDEX_OP(rowIdx,+,colOffset[lastFinite], (byrow ? rowsHasNA : colsHasNA), (byrow ? colsHasNA : rowsHasNA)),
                                    X_NA, colsHasNA || rowsHasNA);
         values[ lastFinite ] = tmp;
         lastFinite--;

--- a/tests/rowRanks_subset.R
+++ b/tests/rowRanks_subset.R
@@ -52,17 +52,17 @@ for (setDimnames in c(TRUE, FALSE)) {
 
       validateIndicesTestMatrix(x, rows, cols,
                                 ftest = rowRanks, fsure = rowRanks_R,
-                                ties.method = "average", useNames = useNames)
+                                ties.method = "average", useNames = useNames, debug = TRUE)
       
       validateIndicesTestMatrix(x, rows, cols,
                                 ftest = colRanks_R_t, fsure = rowRanks_R,
-                                ties.method = "average", useNames = useNames)
+                                ties.method = "average", useNames = useNames, debug = TRUE)
       
       for (perserveShape in c(TRUE, FALSE)) {
         validateIndicesTestMatrix(x, rows, cols,
                                   ftest = colRanks, fsure = colRanks_R,
                                   ties.method = "average", perserveShape = perserveShape,
-                                  useNames = useNames)          
+                                  useNames = useNames, debug = TRUE)          
       }
     }
   }

--- a/tests/rowRanks_subset.R
+++ b/tests/rowRanks_subset.R
@@ -52,17 +52,17 @@ for (setDimnames in c(TRUE, FALSE)) {
 
       validateIndicesTestMatrix(x, rows, cols,
                                 ftest = rowRanks, fsure = rowRanks_R,
-                                ties.method = "average", useNames = useNames, debug = TRUE)
+                                ties.method = "average", useNames = useNames)
       
       validateIndicesTestMatrix(x, rows, cols,
                                 ftest = colRanks_R_t, fsure = rowRanks_R,
-                                ties.method = "average", useNames = useNames, debug = TRUE)
+                                ties.method = "average", useNames = useNames)
       
       for (perserveShape in c(TRUE, FALSE)) {
         validateIndicesTestMatrix(x, rows, cols,
                                   ftest = colRanks, fsure = colRanks_R,
                                   ties.method = "average", perserveShape = perserveShape,
-                                  useNames = useNames, debug = TRUE)          
+                                  useNames = useNames)          
       }
     }
   }


### PR DESCRIPTION
This pull request resolves issue #264 (please confirm). In addition to resolving the unspecified behavior of preprocessor statements interleaving with macros, I have substantially rewritten the code for `rowRanks()` in order to conform with the rest of the internal `matrixStats` C ideoms and weeding out uncessarily repeated code. The most noticable effects are a reduction in code lines and removal of a layer of macros, resulting in a lower numbers of compiled functions.