### PR TITLE
Support for strict headers

### DIFF
--- a/src/000.types.h
+++ b/src/000.types.h
@@ -33,6 +33,8 @@
 #define LDOUBLE_ALLOC(n) ((double*) R_alloc(n, sizeof(double)))
 #endif
 
+
+
 /* Backward compatibility with R (< 3.0.0)
    As in <R>/src/include/Rinternals.h */
 #ifndef R_XLEN_T_MAX
@@ -41,6 +43,26 @@
   #ifndef xlength
     #define xlength length
   #endif
+#endif
+
+
+/* With strict headers (becoming the default), 
+ * the prefixed variants R_Calloc and R_Free 
+ * must be used instead of Calloc and Free. However, the prefixed variants 
+ * do not exist prior to R 3.4.0, so we check whether strict headers are used and
+ * apply the legacy functions if not. 
+ * If future versions of R remove the un-prefixed variants
+ * and no longer display the macro STRICT_R_HEADERS, this workaround will fail.
+ * In such a case, we must enforce the prefixed variants and increase the version
+ * requirement of the package to R 3.4.0.
+ * 
+ */
+#ifdef STRICT_R_HEADERS
+  #define R_CALLOC(num, size) R_Calloc(num, size)
+  #define R_FREE(ptr) R_Free(ptr)
+#else
+  #define R_CALLOC(num, size) Calloc(num, size)
+  #define R_FREE(ptr) Free(ptr)
 #endif
 
 

--- a/src/diff2_lowlevel_template.h
+++ b/src/diff2_lowlevel_template.h
@@ -72,7 +72,7 @@ void CONCAT_MACROS(diff2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx,
     }
   } else {
     /* Allocate temporary work vector (to hold intermediate differences) */
-    tmp = Calloc(nidxs - lag, X_C_TYPE);
+    tmp = R_CALLOC(nidxs - lag, X_C_TYPE);
 
     /* (a) First order of differences */
     for (ii=0; ii < nidxs-lag; ii++) {
@@ -115,7 +115,7 @@ void CONCAT_MACROS(diff2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx,
     }
 
     /* Deallocate temporary work vector */
-    Free(tmp);
+    R_FREE(tmp);
   } /* if (differences ...) */
 }
 

--- a/src/rowDiffs_lowlevel_template.h
+++ b/src/rowDiffs_lowlevel_template.h
@@ -229,7 +229,7 @@ void CONCAT_MACROS(rowDiffs, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t
       nrow_tmp = nrows - lag;
       ncol_tmp = ncols;
     }
-    tmp = Calloc(nrow_tmp*ncol_tmp, X_C_TYPE);
+    tmp = R_CALLOC(nrow_tmp*ncol_tmp, X_C_TYPE);
 
     /* (a) First order of differences */
     DIFF_X_MATRIX_TYPE(x, nrow, rows, nrows, rowsHasNA, cols, ncols, colsHasNA, byrow, lag, tmp, nrow_tmp, ncol_tmp);
@@ -253,7 +253,7 @@ void CONCAT_MACROS(rowDiffs, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t
     DIFF_X_MATRIX(tmp, nrow_tmp, ncol_tmp, byrow, lag, ans, nrow_ans, ncol_ans);
 
     /* Deallocate temporary work matrix */
-    Free(tmp);
+    R_FREE(tmp);
   } /* if (differences ...) */
 }
 

--- a/src/validateIndices_lowlevel_template.h
+++ b/src/validateIndices_lowlevel_template.h
@@ -95,7 +95,7 @@ R_xlen_t* CONCAT_MACROS(validateIndices, X_C_SIGNATURE)(X_C_TYPE *idxs, R_xlen_t
 
   // state < 0
   // use filter as bitset to find out all required idxs
-  Rboolean *filter = Calloc(maxIdx, Rboolean);
+  Rboolean *filter = R_CALLOC(maxIdx, Rboolean);
   count = maxIdx;
   memset(filter, 0, maxIdx*sizeof(Rboolean)); // set to FALSE
   for (ii = 0; ii < nidxs; ++ ii) {
@@ -110,7 +110,7 @@ R_xlen_t* CONCAT_MACROS(validateIndices, X_C_SIGNATURE)(X_C_TYPE *idxs, R_xlen_t
 
   *ansNidxs = count;
   if (count == 0) {
-    Free(filter);
+    R_FREE(filter);
     return NULL;
   }
 
@@ -123,7 +123,7 @@ R_xlen_t* CONCAT_MACROS(validateIndices, X_C_SIGNATURE)(X_C_TYPE *idxs, R_xlen_t
 
   // fill required idxs into ans
   // NOTE: braces is needed here, because of macro-defined function
-  RETURN_VALIDATED_ANS(R_xlen_t, upperBound, !filter[ii], ii, Free(filter););
+  RETURN_VALIDATED_ANS(R_xlen_t, upperBound, !filter[ii], ii, R_FREE(filter););
 }
 
 

--- a/src/weightedMedian_lowlevel_template.h
+++ b/src/weightedMedian_lowlevel_template.h
@@ -32,7 +32,7 @@ double CONCAT_MACROS(weightedMedian, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx, do
   /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
   /* Weights                                                             */
   /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-  wtmp = Calloc(nidxs, double);
+  wtmp =R_CALLOC(nidxs, double);
 
   /* Check for missing, negative, and infinite weights */
   nxt = 0;
@@ -48,7 +48,7 @@ double CONCAT_MACROS(weightedMedian, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx, do
     weight = R_INDEX_GET(w, ((idxs == NULL) ? (ii) : idxs[ii]), NA_REAL, 1);
     if (ISNAN(weight)) {
       if (!narm) {
-        Free(wtmp);
+        R_FREE(wtmp);
         return NA_REAL;
       }
     } else if (weight <= 0) {
@@ -66,7 +66,7 @@ double CONCAT_MACROS(weightedMedian, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx, do
           value = R_INDEX_GET(x, ((idxs == NULL) ? (jj) : idxs[jj]), X_NA, idxsHasNA);
           if (X_ISNAN(value)) {
             if (!narm) {
-              Free(wtmp);
+              R_FREE(wtmp);
               return NA_REAL;
             }
           } else {
@@ -76,7 +76,7 @@ double CONCAT_MACROS(weightedMedian, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx, do
           }
         } else if (ISNAN(weight)) {
           if (!narm) {
-            Free(wtmp);
+            R_FREE(wtmp);
             return NA_REAL;
           }
         }
@@ -88,7 +88,7 @@ double CONCAT_MACROS(weightedMedian, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx, do
       value = R_INDEX_GET(x, ((idxs == NULL) ? (ii) : idxs[ii]), X_NA, idxsHasNA);
       if (X_ISNAN(value)) {
         if (!narm) {
-          Free(wtmp);
+          R_FREE(wtmp);
           return NA_REAL;
         }
       } else {
@@ -106,7 +106,7 @@ double CONCAT_MACROS(weightedMedian, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx, do
 
   /* Nothing to do? */
   if (nxt == 0) {
-    Free(wtmp);
+    R_FREE(wtmp);
     return NA_REAL;
   }
 
@@ -114,7 +114,7 @@ double CONCAT_MACROS(weightedMedian, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx, do
   /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
   /* Copy (x,w) to work with and calculate total weight                  */
   /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-  xtmp = Calloc(nxt, X_C_TYPE);
+  xtmp =R_CALLOC(nxt, X_C_TYPE);
   jj = 0;
   wtotal = 0;
   for (ii=0; ii < nidxs; ii++) {
@@ -138,8 +138,8 @@ double CONCAT_MACROS(weightedMedian, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx, do
   /* Early stopping? */
   if (nx == 1) {
     res = (double)x[0];
-    Free(xtmp);
-    Free(wtmp);
+    R_FREE(xtmp);
+    R_FREE(wtmp);
     return res;
   }
 
@@ -165,8 +165,8 @@ double CONCAT_MACROS(weightedMedian, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx, do
       res = ((double)x[half-1] + (double)x[half]) / 2;
     }
 
-    Free(xtmp);
-    Free(wtmp);
+    R_FREE(xtmp);
+    R_FREE(wtmp);
     return res;
   }
 
@@ -176,12 +176,12 @@ double CONCAT_MACROS(weightedMedian, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx, do
   /* one) according to the reordered vector.                             */
   /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
   /* (a) Sort x */
-  idxs_int = Calloc(nx, int);
+  idxs_int =R_CALLOC(nx, int);
   for (ii = 0; ii < nx; ii++) idxs_int[ii] = ii;
   X_QSORT_I(x, idxs_int, 1, nx);
 
   /* (b) Normalized cumulative weights */
-  wcum = Calloc(nx, double);
+  wcum =R_CALLOC(nx, double);
   tmp_d2 = 0;
   /* Index where cumulative weight passed 1/2 */
   half = nx+1; /* Default is last */
@@ -209,16 +209,16 @@ double CONCAT_MACROS(weightedMedian, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx, do
       }
     }
   }
-  Free(wtmp);
-  Free(idxs_int);
+  R_FREE(wtmp);
+  R_FREE(idxs_int);
 
 
   /* Two special cases where more than half of the total weight is at
      a) the first, or b) the last value */
   if (half == 0 || half == nx) {
     res = (double)x[half];
-    Free(wcum);
-    Free(xtmp);
+    R_FREE(wcum);
+    R_FREE(xtmp);
     return res;
   }
 
@@ -242,8 +242,8 @@ double CONCAT_MACROS(weightedMedian, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx, do
     /* The corresponding x value */
     res = dx + x[half];
 
-    Free(wcum);
-    Free(xtmp);
+    R_FREE(wcum);
+    R_FREE(xtmp);
 
     return res;
   }
@@ -290,8 +290,8 @@ printf("x[half+(-1:1)]=c(%g, %g, %g)\n", x[half-1-1], x[half-1], x[half-1+1]);
     }
   }
 
-  Free(wcum);
-  Free(xtmp);
+  R_FREE(wcum);
+  R_FREE(xtmp);
 
   return res;
 }


### PR DESCRIPTION
This PR should resolve issue #266 and solves this by using the prefixed versions of `Calloc` and `Free` when, and only when, `STRICT_R_HEADERS` is defined.