### PR TITLE
Use long doubles unconditionally

### DIFF
--- a/src/000.types.h
+++ b/src/000.types.h
@@ -27,12 +27,6 @@
   #define SUBSETTED_REAL 2
 #endif
 
-
-/* As in <R>/src/include/Defn.h */
-
-#define LDOUBLE long double
-#define LDOUBLE_ALLOC(n) R_allocLD(n)
-
 /* define NA_R_XLEN_T */
 #ifdef LONG_VECTOR_SUPPORT
   #define R_XLEN_T_MIN -R_XLEN_T_MAX-1

--- a/src/000.types.h
+++ b/src/000.types.h
@@ -29,14 +29,9 @@
 
 
 /* As in <R>/src/include/Defn.h */
-#ifdef HAVE_LONG_DOUBLE
+
 #define LDOUBLE long double
 #define LDOUBLE_ALLOC(n) R_allocLD(n)
-#else
-#define LDOUBLE double
-#define LDOUBLE_ALLOC(n) ((double*) R_alloc(n, sizeof(double)))
-#endif
-
 
 /* define NA_R_XLEN_T */
 #ifdef LONG_VECTOR_SUPPORT

--- a/src/binMeans_lowlevel_template.h
+++ b/src/binMeans_lowlevel_template.h
@@ -29,7 +29,7 @@
 void METHOD_NAME(double *y, R_xlen_t ny, double *x, R_xlen_t nx, double *bx, R_xlen_t nbins, double *ans, int *count) {
   R_xlen_t ii = 0, jj = 0, iStart=0;
   R_xlen_t n = 0;
-  LDOUBLE sum = 0.0;
+  long double sum = 0.0;
   int warn = 0;
 
   // Count?
@@ -80,7 +80,7 @@ void METHOD_NAME(double *y, R_xlen_t ny, double *x, R_xlen_t nx, double *bx, R_x
       sum += y[ii];
       ++n;
 
-      /* Early LDOUBLE stopping? */
+      /* Early long double stopping? */
       if (n % 1048576 == 0 && !R_FINITE(sum)) break;
     }
 

--- a/src/logSumExp_lowlevel_template.h
+++ b/src/logSumExp_lowlevel_template.h
@@ -36,7 +36,7 @@
 double logSumExp_double(double *x, R_xlen_t *idxs, R_xlen_t nidxs, int idxsHasNA, int narm, int hasna, R_xlen_t by, double *xx) {
   R_xlen_t ii, iMax, idx;
   double xii, xMax;
-  LDOUBLE sum;
+  long double sum;
   int hasna2 = FALSE; /* Indicates whether NAs where detected or not */
   int xMaxIsNA;
   int noidxs;
@@ -193,7 +193,7 @@ double logSumExp_double(double *x, R_xlen_t *idxs, R_xlen_t nidxs, int idxsHasNA
         sum += exp(xii - xMax);
       }
 
-      /* Early LDOUBLE stopping on -Inf/+Inf and user interrupt? */
+      /* Early long double stopping on -Inf/+Inf and user interrupt? */
       if (ii % 1048576 == 0) {
         if (!R_FINITE(sum)) break;
         R_CheckUserInterrupt();
@@ -223,7 +223,7 @@ double logSumExp_double(double *x, R_xlen_t *idxs, R_xlen_t nidxs, int idxsHasNA
         sum += exp(xii - xMax);
       }
 
-      /* Early LDOUBLE stopping on -Inf/+Inf and user interrupt? */
+      /* Early long double stopping on -Inf/+Inf and user interrupt? */
       if (ii % 1048576 == 0) {
         if (!R_FINITE(sum)) break;
         R_CheckUserInterrupt();

--- a/src/mean2_lowlevel_template.h
+++ b/src/mean2_lowlevel_template.h
@@ -29,12 +29,12 @@ double CONCAT_MACROS(mean2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx,
                      int narm, int refine) {
   X_C_TYPE value;
   R_xlen_t ii;
-  LDOUBLE sum = 0, avg = R_NaN;
+  long double sum = 0, avg = R_NaN;
   int noidxs;
   if (idxs == NULL) { noidxs = 1; } else { noidxs = 0;}
   
 #if X_TYPE == 'r'
-  LDOUBLE rsum = 0;
+  long double rsum = 0;
 #endif
   R_xlen_t count = 0;
 
@@ -52,7 +52,7 @@ double CONCAT_MACROS(mean2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx,
     
 #if X_TYPE == 'i'
     if (!X_ISNAN(value)) {
-      sum += (LDOUBLE)value;
+      sum += (long double)value;
       ++count;
     } else if (!narm) {
         sum = R_NaReal;
@@ -60,12 +60,12 @@ double CONCAT_MACROS(mean2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx,
     }
 #elif X_TYPE == 'r'
     if (!narm) {
-      sum += (LDOUBLE)value;
+      sum += (long double)value;
       ++count;
       /* Early stopping if sum is NA_real_ (but not NaN, -Inf, or +Inf) */
       if (ii % 1048576 == 0 && ISNA(sum)) break;
     } else if (!ISNAN(value)) {
-      sum += (LDOUBLE)value;
+      sum += (long double)value;
       ++count;
     }
 #endif
@@ -84,7 +84,7 @@ double CONCAT_MACROS(mean2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx,
       for (ii=0; ii < nidxs; ++ii) {
         value = R_INDEX_GET(x, ((idxs == NULL) ? (ii) : idxs[ii]), X_NA, idxsHasNA);
         if (!narm || !ISNAN(value)) {
-          rsum += (LDOUBLE)(value - avg);
+          rsum += (long double)(value - avg);
         }
       }
       avg += (rsum / count);

--- a/src/productExpSumLog_lowlevel_template.h
+++ b/src/productExpSumLog_lowlevel_template.h
@@ -26,7 +26,7 @@
 double CONCAT_MACROS(productExpSumLog, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx,
                      R_xlen_t *idxs, R_xlen_t nidxs, int idxsHasNA,
                      int narm, int hasna) {
-  LDOUBLE y = 0.0, t;
+  long double y = 0.0, t;
   R_xlen_t ii;
   int isneg = 0;
   int hasZero = 0;
@@ -64,7 +64,7 @@ double CONCAT_MACROS(productExpSumLog, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx,
       Rprintf("#%d: x=%g, is.nan(x)=%d, abs(x)=%g, is.nan(abs(x))=%d, log(abs(x))=%g, is.nan(log(abs(x)))=%d, sum=%g, is.nan(sum)=%d\n", ii, x[ii], R_IsNaN(x[ii]), X_ABS(x[ii]), R_IsNaN(abs(x[ii])), t, R_IsNaN(y), y, R_IsNaN(y));  */
 
 #if X_TYPE == 'r'
-    /* Early stopping? Special for long LDOUBLE vectors */
+    /* Early stopping? Special for long long double vectors */
     if (ii % 1048576 == 0 && ISNAN(y)) break;
 #endif
   }

--- a/src/rowCumprods_lowlevel_template.h
+++ b/src/rowCumprods_lowlevel_template.h
@@ -34,7 +34,7 @@ void CONCAT_MACROS(rowCumprods, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xle
   R_xlen_t ii, jj, kk, kk_prev, idx;
   R_xlen_t colBegin;
   X_C_TYPE xvalue;
-  LDOUBLE value;
+  long double value;
   int nocols, norows;
   
   if (cols == NULL) { nocols = 1; } else { nocols = 0; }
@@ -130,7 +130,7 @@ void CONCAT_MACROS(rowCumprods, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xle
             oks[ii] = 0;
             ans[kk] = ANS_NA;
           } else {
-            value = (LDOUBLE) ans[kk_prev] * (LDOUBLE) xvalue;
+            value = (long double) ans[kk_prev] * (long double) xvalue;
             /* Integer overflow? */
             if (value < R_INT_MIN_d || value > R_INT_MAX_d) {
               oks[ii] = 0;
@@ -144,7 +144,7 @@ void CONCAT_MACROS(rowCumprods, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xle
           ans[kk] = ANS_NA;
         }
 #else
-        ans[kk] = (ANS_C_TYPE) ((LDOUBLE) ans[kk_prev] * (LDOUBLE) xvalue);
+        ans[kk] = (ANS_C_TYPE) ((long double) ans[kk_prev] * (long double) xvalue);
 #endif
 
         kk++;
@@ -195,7 +195,7 @@ void CONCAT_MACROS(rowCumprods, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xle
             ok = 0;
             ans[kk] = ANS_NA;
           } else {
-            value *= (LDOUBLE) xvalue;
+            value *= (long double) xvalue;
             /* Integer overflow? */
             if (value < R_INT_MIN_d || value > R_INT_MAX_d) {
               ok = 0;

--- a/src/rowCumsums_lowlevel_template.h
+++ b/src/rowCumsums_lowlevel_template.h
@@ -34,7 +34,7 @@ void CONCAT_MACROS(rowCumsums, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen
   R_xlen_t ii, jj, kk, kk_prev, idx;
   R_xlen_t colBegin;
   X_C_TYPE xvalue;
-  LDOUBLE value;
+  long double value;
   int norows, nocols;
   if (cols == NULL) { nocols = 1; } else { nocols = 0; }
   if (rows == NULL) { norows = 1; } else { norows = 0; }
@@ -125,7 +125,7 @@ void CONCAT_MACROS(rowCumsums, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen
             oks[ii] = 0;
             ans[kk] = ANS_NA;
           } else {
-            value = (LDOUBLE) ans[kk_prev] + (LDOUBLE) xvalue;
+            value = (long double) ans[kk_prev] + (long double) xvalue;
             /* Integer overflow? */
             if (value < R_INT_MIN_d || value > R_INT_MAX_d) {
               oks[ii] = 0;
@@ -139,7 +139,7 @@ void CONCAT_MACROS(rowCumsums, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen
           ans[kk] = ANS_NA;
         }
 #else
-        ans[kk] = (ANS_C_TYPE) ((LDOUBLE) ans[kk_prev] + (LDOUBLE) xvalue);
+        ans[kk] = (ANS_C_TYPE) ((long double) ans[kk_prev] + (long double) xvalue);
 #endif
 
         kk++;
@@ -191,7 +191,7 @@ void CONCAT_MACROS(rowCumsums, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen
             ok = 0;
             ans[kk] = ANS_NA;
           } else {
-            value += (LDOUBLE) xvalue;
+            value += (long double) xvalue;
             /* Integer overflow? */
             if (value < R_INT_MIN_d || value > R_INT_MAX_d) {
               ok = 0;

--- a/src/rowMeans2_lowlevel_template.h
+++ b/src/rowMeans2_lowlevel_template.h
@@ -22,7 +22,7 @@ void CONCAT_MACROS(rowMeans2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_
   R_xlen_t ii, jj, idx;
   R_xlen_t *colOffset;
   X_C_TYPE value;
-  LDOUBLE sum, avg;
+  long double sum, avg;
   R_xlen_t count;
   int nocols, norows;
 
@@ -91,7 +91,7 @@ void CONCAT_MACROS(rowMeans2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_
         
 #if X_TYPE == 'i'
       if (!X_ISNAN(value)) {
-        sum += (LDOUBLE)value;
+        sum += (long double)value;
         ++count;
       } else if (!narm) {
         sum = R_NaReal;
@@ -99,11 +99,11 @@ void CONCAT_MACROS(rowMeans2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_
       }
 #elif X_TYPE == 'r'
       if (!narm) {
-        sum += (LDOUBLE)value;
+        sum += (long double)value;
         ++count;
         if (jj % 1048576 == 0 && ISNA(sum)) break;
       } else if (!ISNAN(value)) {
-        sum += (LDOUBLE)value;
+        sum += (long double)value;
         ++count;
       }
 #endif
@@ -143,10 +143,10 @@ void CONCAT_MACROS(rowMeans2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_
           }
         
           if (!narm) {
-            sum += (LDOUBLE)(value) - avg;
+            sum += (long double)(value) - avg;
             if (jj % 1048576 == 0 && ISNA(sum)) break;
           } else if (!ISNAN(value)) {
-            sum += (LDOUBLE)(value) - avg;
+            sum += (long double)(value) - avg;
           }
         }
         avg = avg + sum / count;

--- a/src/rowSums2_lowlevel_template.h
+++ b/src/rowSums2_lowlevel_template.h
@@ -32,8 +32,8 @@ void CONCAT_MACROS(rowSums2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t
     /* NOTE: For maintaining a tidy codebase, we bring variables for both
      * colsums and rowsums in scope, but only one of them will ever be used
      * at given call to the function */
-    LDOUBLE *rowSum;
-    LDOUBLE colSum;
+    long double *rowSum;
+    long double colSum;
     
     /* If there are no missing values, don't try to remove them. */
     if (hasna == FALSE)
@@ -43,7 +43,7 @@ void CONCAT_MACROS(rowSums2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t
     if (rows == NULL) { norows = 1; } else { norows = 0; }
     
     if (byrow) {
-      rowSum = LDOUBLE_ALLOC(nrows);
+      rowSum = R_allocLD(nrows);
       /*
        * If nrows == 0, a NULL pointer is returned.
        * Calling memset() with a NULL pointer is apparently undefined behavior,
@@ -52,7 +52,7 @@ void CONCAT_MACROS(rowSums2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t
       if (nrows > 0) {
         /* Ensures that all elements of array are intialized to zero,
          * this is VERY important */
-        memset(rowSum, 0, nrows*  sizeof(LDOUBLE));
+        memset(rowSum, 0, nrows*  sizeof(long double));
       }
       
     }
@@ -91,13 +91,13 @@ void CONCAT_MACROS(rowSums2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t
 #if X_TYPE == 'i'
         if (byrow) {
           if (!X_ISNAN(value)) {
-            rowSum[ii] += (LDOUBLE)value;
+            rowSum[ii] += (long double)value;
           } else if (!narm) {
             rowSum[ii] = R_NaReal;
           }
         } else {
           if (!X_ISNAN(value)) {
-            colSum += (LDOUBLE)value;
+            colSum += (long double)value;
           } else if (!narm) {
             colSum = R_NaReal;
             /* This optimization is harder to make for row sums
@@ -109,15 +109,15 @@ void CONCAT_MACROS(rowSums2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nrow, R_xlen_t
 #elif X_TYPE == 'r'
         if (byrow) {
           if (!narm) {
-            rowSum[ii] += (LDOUBLE)value;
+            rowSum[ii] += (long double)value;
           } else if (!ISNAN(value)) {
-            rowSum[ii] += (LDOUBLE)value;
+            rowSum[ii] += (long double)value;
             }
         } else {
           if (!narm) {
-            colSum += (LDOUBLE)value;
+            colSum += (long double)value;
           } else if (!ISNAN(value)) {
-            colSum += (LDOUBLE)value;
+            colSum += (long double)value;
               if (jj % 1048576 == 0 && ISNA(colSum)) {
                 break;
               }

--- a/src/sum2_lowlevel_template.h
+++ b/src/sum2_lowlevel_template.h
@@ -28,7 +28,7 @@ double CONCAT_MACROS(sum2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx,
                      int narm) {
   X_C_TYPE value;
   R_xlen_t ii;
-  LDOUBLE sum = 0;
+  long double sum = 0;
   int noidxs;
   if (idxs == NULL) { noidxs = 1; } else { noidxs = 0; }
 
@@ -46,18 +46,18 @@ double CONCAT_MACROS(sum2, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx,
     
 #if X_TYPE == 'i'
     if (!X_ISNAN(value)) {
-      sum += (LDOUBLE)value;
+      sum += (long double)value;
     } else if (!narm) {
         sum = R_NaReal;
         break;
     }
 #elif X_TYPE == 'r'
     if (!narm) {
-      sum += (LDOUBLE)value;
+      sum += (long double)value;
       /* Early stopping if sum is NA_real_ (but not NaN, -Inf, or +Inf) */
       if (ii % 1048576 == 0 && ISNA(sum)) break;
     } else if (!ISNAN(value)) {
-      sum += (LDOUBLE)value;
+      sum += (long double)value;
     }
 #endif
   } /* for (ii ...) */

--- a/src/weightedMean_lowlevel_template.h
+++ b/src/weightedMean_lowlevel_template.h
@@ -23,8 +23,8 @@ double CONCAT_MACROS(weightedMean, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx, doub
   X_C_TYPE value;
   double weight;
   R_xlen_t i;
-  LDOUBLE sum = 0, wtotal = 0;
-  LDOUBLE avg = R_NaN;
+  long double sum = 0, wtotal = 0;
+  long double avg = R_NaN;
 
   for (i=0; i < nidxs; i++) {
     /*
@@ -49,17 +49,17 @@ double CONCAT_MACROS(weightedMean, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx, doub
         break;
       }
     } else {
-      sum += (LDOUBLE)weight * (LDOUBLE)value;
+      sum += (long double)weight * (long double)value;
       wtotal += weight;
     }
 #elif X_TYPE == 'r'
     if (!narm) {
-      sum += (LDOUBLE)weight * (LDOUBLE)value;
+      sum += (long double)weight * (long double)value;
       wtotal += weight;
-      /* Early stopping? Special for long LDOUBLE vectors */
+      /* Early stopping? Special for long long double vectors */
       if (i % 1048576 == 0 && ISNAN(sum)) break;
     } else if (!X_ISNAN(value)) {
-      sum += (LDOUBLE)weight * (LDOUBLE)value;
+      sum += (long double)weight * (long double)value;
       wtotal += weight;
     }
 #endif
@@ -87,11 +87,11 @@ double CONCAT_MACROS(weightedMean, X_C_SIGNATURE)(X_C_TYPE *x, R_xlen_t nx, doub
 
         value = R_INDEX_GET(x, ((idxs == NULL) ? (i) : idxs[i]), X_NA, idxsHasNA);
         if (!narm) {
-          sum += (LDOUBLE)weight * (value - avg);
-          /* Early stopping? Special for long LDOUBLE vectors */
+          sum += (long double)weight * (value - avg);
+          /* Early stopping? Special for long long double vectors */
           if (i % 1048576 == 0 && ISNAN(sum)) break;
         } else if (!ISNAN(value)) {
-          sum += (LDOUBLE)weight * (value - avg);
+          sum += (long double)weight * (value - avg);
         }
       }
       avg += (sum / wtotal);


### PR DESCRIPTION
AFAICT this should be ok. Lots of CRAN packages already use long doubles unconditionally and is part of the C standard. I think checking is likely superfluous.

This will close #278 and should fix #96 (and possibly other issues related to discrepancies with base R). 