### PR TITLE
fix: pass colsHasNA to rowCumsums_dbl to prevent segfault with NA cols

### DIFF
--- a/src/rowCumsums.c
+++ b/src/rowCumsums.c
@@ -39,7 +39,7 @@ SEXP rowCumsums(SEXP x, SEXP dim, SEXP rows, SEXP cols, SEXP byRow, SEXP useName
   /* Double matrices are more common to use. */
   if (isReal(x)) {
     PROTECT(ans = allocMatrix(REALSXP, nrows, ncols));
-    rowCumsums_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, rowsHasNA, byrow, REAL(ans));
+    rowCumsums_dbl(REAL(x), nrow, ncol, crows, nrows, rowsHasNA, ccols, ncols, colsHasNA, byrow, REAL(ans));
     if (usenames) {
       SEXP dimnames = getAttrib(x, R_DimNamesSymbol);
       if (dimnames != R_NilValue) {


### PR DESCRIPTION
Pretty sure this is a copy-paste typo. Reprex for the segfault: 

```r
rowCumsums(matrix(as.double(1:12), 3), cols=c(1L, NA, 3L))
```