### PR TITLE
fix: pass per-set weight submatrix to FUN in rowAvgsPerColSet

### DIFF
--- a/R/rowAvgsPerColSet.R
+++ b/R/rowAvgsPerColSet.R
@@ -108,15 +108,16 @@ rowAvgsPerColSet <- function(X, W = NULL, rows = NULL, S,
     # Extract set of columns from X
     jj <- jj[is.finite(jj)]
     Zjj <- X[, jj, drop = FALSE]
+    if (hasW) Wjj <- W[, jj, drop = FALSE]
     jj <- NULL  # Not needed anymore
 
     if (tFUN) {
       Zjj <- t(Zjj)
+      if (hasW) Wjj <- t(Wjj)
     }
 
     # Average by weights
     if (hasW) {
-      Wjj <- W[, jj, drop = FALSE]
       Zjj <- FUN(Zjj, W = Wjj, ..., na.rm = na.rm)
       Wjj <- NULL  # Not needed anymore
     } else {

--- a/tests/rowAvgsPerColSet.R
+++ b/tests/rowAvgsPerColSet.R
@@ -88,16 +88,16 @@ print(Z2)
 # - - - - - - - - - - - - - - - - - - - - - - - - - -
 rowWMean <- function(x, W, ...) rowSums(x * W) / rowSums(W)
 Z <- rowAvgsPerColSet(X, W = W, S = S, FUN = rowWMean)
-Z0 <- cbind(s1 = rowWMean(X[, 1:2], W[, 1:2]),
-            s2 = rowWMean(X[, 3:4], W[, 3:4]),
-            s3 = rowWMean(X[, 5:6], W[, 5:6]))
+Z0 <- cbind(s1 = rowWMean(X[, S[, 1L]], W[, S[, 1L]]),
+            s2 = rowWMean(X[, S[, 2L]], W[, S[, 2L]]),
+            s3 = rowWMean(X[, S[, 3L]], W[, S[, 3L]]))
 stopifnot(identical(drop(Z), Z0))
 
 colWMean <- function(x, W, ...) colSums(x * W) / colSums(W)
 Z <- colAvgsPerRowSet(X, W = W, S = S, FUN = colWMean)
-Z0 <- rbind(s1 = colWMean(X[1:2, ], W[1:2, ]),
-            s2 = colWMean(X[3:4, ], W[3:4, ]),
-            s3 = colWMean(X[5:6, ], W[5:6, ]))
+Z0 <- rbind(s1 = colWMean(X[S[, 1L], ], W[S[, 1L], ]),
+            s2 = colWMean(X[S[, 2L], ], W[S[, 2L], ]),
+            s3 = colWMean(X[S[, 3L], ], W[S[, 3L], ]))
 stopifnot(identical(drop(Z), Z0))
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/tests/rowAvgsPerColSet.R
+++ b/tests/rowAvgsPerColSet.R
@@ -84,6 +84,23 @@ Z2 <- colAvgsPerRowSet(X, W = W, S = S, FUN = colWeightedMeans)
 print(Z2)
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Weighted FUN() must receive 'W' subset to each set's columns / rows
+# - - - - - - - - - - - - - - - - - - - - - - - - - -
+rowWMean <- function(x, W, ...) rowSums(x * W) / rowSums(W)
+Z <- rowAvgsPerColSet(X, W = W, S = S, FUN = rowWMean)
+Z0 <- cbind(s1 = rowWMean(X[, 1:2], W[, 1:2]),
+            s2 = rowWMean(X[, 3:4], W[, 3:4]),
+            s3 = rowWMean(X[, 5:6], W[, 5:6]))
+stopifnot(identical(drop(Z), Z0))
+
+colWMean <- function(x, W, ...) colSums(x * W) / colSums(W)
+Z <- colAvgsPerRowSet(X, W = W, S = S, FUN = colWMean)
+Z0 <- rbind(s1 = colWMean(X[1:2, ], W[1:2, ]),
+            s2 = colWMean(X[3:4, ], W[3:4, ]),
+            s3 = colWMean(X[5:6, ], W[5:6, ]))
+stopifnot(identical(drop(Z), Z0))
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Result should always be a matrix, including when nrow(X) <= 1
 # (https://github.com/HenrikBengtsson/matrixStats/issues/108)
 # - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
The apply() loop cleared `jj` (`jj <- NULL`) before subsetting the weight matrix.
I've added a test for this and tried to stick to the repo's style, but please feel free to make adjustments.
But this probably requires a more careful review.