### PR TITLE
test: cover diff2 names under GC pressure

### DIFF
--- a/tests/diff2.R
+++ b/tests/diff2.R
@@ -37,3 +37,12 @@ for (mode in c("integer", "double")) {
     }
   } # for (has_na ...)
 }
+
+local({
+  ## Guard the named result while setNamesDiff() allocates (#258)
+  x <- setNames(as.double(seq_len(10L)), LETTERS[seq_len(10L)])
+  expected <- diff(x)
+  previous <- gctorture(TRUE)
+  actual <- tryCatch(diff2(x), finally = gctorture(previous))
+  stopifnot(identical(actual, expected))
+})


### PR DESCRIPTION
## Summary

Add regression coverage for named `diff2()` results under forced garbage collection.

## Thanks to maintainers

Thanks for maintaining matrixStats and for preserving the detailed failure trace in #258.

## Issue or motivation

Closes #258. The reported `names() applied to a non-vector` error and segfault were sporadic, so the regular value tests did not exercise the relevant garbage-collection timing.

## Root cause

Before 15fd5bc, the result vector was unprotected while `setNamesDiff()` allocated its names vector. A collection at that point could reclaim the result and lead to either reported failure. The protection fix is already on `develop`; the issue was not linked to it and had no regression test.

## Change

Run a named double vector through `diff2()` with `gctorture()` enabled, compare it with `base::diff()`, and restore the prior torture setting even if the call errors.

## Tests

- Reversing the result-vector protection in a temporary build made the new test segfault deterministically (exit 139).
- `Rscript --vanilla tests/diff2.R`
- `R CMD build`
- `R CMD check --as-cran`: all tests, vignettes, and manuals passed; the two NOTEs were the development version number and unavailable local HTML Tidy/V8 checks.

## Scope

This adds one regression case only. It does not change `diff2()` behavior, C code, or other tests.
